### PR TITLE
Allow to use relative path of input LAMMPS data.

### DIFF
--- a/workflow/DpFreeEnergy-aiida.py
+++ b/workflow/DpFreeEnergy-aiida.py
@@ -40,7 +40,8 @@ def all_start_check(dag_run):
 
     work_base_abs_dir = os.path.realpath(work_base_dir)
 
-    dag_work_dirname=str(target_temp)+'K-'+str(target_pres)+'bar-'+str(conf_lmp)
+    conf_lmp_name = os.path.basename(conf_lmp)
+    dag_work_dirname=str(target_temp)+'K-'+str(target_pres)+'bar-'+str(conf_lmp_name)
     dag_work_dir=os.path.join(work_base_abs_dir, dag_work_dirname)
     
     assert os.path.isdir(work_base_dir) is True,  f'work_base_dir {work_base_dir} must exist '

--- a/workflow/DpFreeEnergy.py
+++ b/workflow/DpFreeEnergy.py
@@ -59,7 +59,8 @@ def all_start_check():
     else:
         pass
 
-    conf_lmp_abs_path = os.path.join(work_base_abs_dir, conf_lmp)
+    conf_lmp_name = os.path.basename(conf_lmp)
+    conf_lmp_abs_path = os.path.join(work_base_abs_dir, conf_lmp_name)
     assert os.path.isfile(conf_lmp_abs_path) is True,  f'structure file {conf_lmp_abs_path} must exist'
     assert str(ti_path) in ["t", "p"], f'value for "path" must be "t" or "p" '
 

--- a/workflow/DpFreeEnergyWater.py
+++ b/workflow/DpFreeEnergyWater.py
@@ -54,7 +54,8 @@ def all_start_check():
 
     work_base_abs_dir = os.path.realpath(work_base_dir)
 
-    dag_work_dirname=str(target_temp)+'K-'+str(target_pres)+'bar-'+str(conf_lmp)
+    conf_lmp_name = os.path.basename(conf_lmp)
+    dag_work_dirname=str(target_temp)+'K-'+str(target_pres)+'bar-'+str(conf_lmp_name)
     dag_work_dir=os.path.join(work_base_abs_dir, dag_work_dirname)
 
     assert os.path.isdir(work_base_dir) is True,  f'work_base_dir {work_base_dir} must exist '


### PR DESCRIPTION
Without this PR, the workflow fails to create file with path prefix like `../`.