### PR TITLE
Fix missing paths in HTI & TI.

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -224,8 +224,10 @@ def make_tasks(iter_name, jdata, if_meam=None):
         # os.chdir(work_path)
 
         relative_link_file(equi_conf, task_abs_dir)
+        task_model = model
         if model:
             relative_link_file(model, task_abs_dir)
+            task_model = os.path.basename(model)
         if if_meam:
             relative_link_file(meam_model['library'], task_abs_dir)
             relative_link_file(meam_model['potential'], task_abs_dir)
@@ -239,8 +241,8 @@ def make_tasks(iter_name, jdata, if_meam=None):
         if 'nvt' in ens and path == 't' :
             lmp_str \
                 = _gen_lammps_input(os.path.basename(equi_conf),
-                                    mass_map, 
-                                    model,
+                                    mass_map,
+                                    task_model,
                                     nsteps, 
                                     timestep,
                                     ens,
@@ -258,8 +260,8 @@ def make_tasks(iter_name, jdata, if_meam=None):
         elif 'npt' in ens and (path == 't' or path == 't-ginv'):
             lmp_str \
                 = _gen_lammps_input(os.path.basename(equi_conf),
-                                    mass_map, 
-                                    model,
+                                    mass_map,
+                                    task_model,
                                     nsteps, 
                                     timestep,
                                     ens,
@@ -278,8 +280,8 @@ def make_tasks(iter_name, jdata, if_meam=None):
         elif 'npt' in ens and path == 'p' :
             lmp_str \
                 = _gen_lammps_input(os.path.basename(equi_conf),
-                                    mass_map, 
-                                    model,
+                                    mass_map,
+                                    task_model,
                                     nsteps, 
                                     timestep,
                                     ens,

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -204,19 +204,15 @@ def make_tasks(iter_name, jdata, if_meam=None):
 
     # cwd = os.getcwd()
     # os.chdir(iter_name)
-    relative_link_file(equi_conf, job_abs_dir)
+    ti_settings['equi_conf'] = relative_link_file(equi_conf, job_abs_dir)
     if model:
-        relative_link_file(model, job_abs_dir)
+        ti_settings['model'] = relative_link_file(model, job_abs_dir)
     if if_meam:
         relative_link_file(meam_model['library'], job_abs_dir)
         relative_link_file(meam_model['potential'], job_abs_dir)
 
-    with open(os.path.join(job_abs_dir, 
-        'ti_settings.json'), 'w') as fp:
-        json.dump(ti_settings, fp, indent=4)
-
     with open(os.path.join(job_abs_dir, 'ti_settings.json'),'w') as f:
-            json.dump(ti_settings, f, indent=4)
+        json.dump(ti_settings, f, indent=4)
 
     for ii in range(ntasks) :
         task_dir = os.path.join(job_abs_dir, 'task.%06d' % ii)

--- a/tests/benchmark_ti_water/new_job/task.000003/in.lammps
+++ b/tests/benchmark_ti_water/new_job/task.000003/in.lammps
@@ -18,7 +18,7 @@ change_box      all triclinic
 mass            1 16.000000
 mass            2 2.000000
 # --------------------- FORCE FIELDS ---------------------
-pair_style      deepmd benchmark_ti_water/graph.pb
+pair_style      deepmd graph.pb
 pair_coeff
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin

--- a/workflow/DpFreeEnergy.py
+++ b/workflow/DpFreeEnergy.py
@@ -155,7 +155,7 @@ def NVT_start(start_info, *, NPT_end_info):
 def NVT_sim(job_work_dir):
     submission = get_empty_submission(job_work_dir)
     task = Task(command='lmp -i in.lammps', task_work_path='./',
-        forward_files=['in.lammps', '*lmp', 'graph.pb'], backward_files=['log.lammps'])
+        forward_files=['in.lammps', '*lmp', 'graph.pb'], backward_files=['log.lammps', 'out.lmp'])
     submission.register_task_list([task])
     submission.run_submission()
     return job_work_dir

--- a/workflow/DpFreeEnergyWater.py
+++ b/workflow/DpFreeEnergyWater.py
@@ -160,7 +160,7 @@ def NVT_start(start_info, *, NPT_end_info):
 def NVT_sim(job_work_dir):
     submission = get_empty_submission(job_work_dir)
     task = Task(command='lmp -i in.lammps', task_work_path='./',
-        forward_files=['in.lammps', '*lmp', 'graph.pb'], backward_files=['log.lammps'])
+        forward_files=['in.lammps', '*lmp', 'graph.pb'], backward_files=['log.lammps', 'out.lmp'])
     submission.register_task_list([task])
     submission.run_submission()
     return job_work_dir


### PR DESCRIPTION
In a HTI task, it tries to start from snapshot of NVT simulation.
When using remote resource through `SSHContext` or `HDFSContext`, we must tell dpdispatcher to fetch `out.lmp` as a backward file.

In a TI task, it creates a symbolic link to model in each task working directory.
However, the model path is not corrected to a relative one in LAMMPS INPUT. If no shared storage is available, MD run will fail to find model.

In `TI_end` stage, it get atom count from `equi_conf` from `ti_settings.json` where path is relative to `job_work_dir`. However, the working directory of DPTI process launched by Airflow is unstable. Thus, we need dump absolute path in `TI_start` stage.