### PR TITLE
fix codecov

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: pip install . coverage codecov
+      run: pip install . coverage
     - name: Test
       run: cd tests && coverage run --source=../dpti -m unittest && cd .. && coverage combine tests/.coverage && coverage report
-    - run: codecov
+    - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Codecov python package is deprecated and does not work any more. This patch migrates it to another version.