### PR TITLE
Update ti.py | enhancing data precision

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -83,14 +83,15 @@ def _gen_lammps_input (conf_file,
     ret += 'neighbor        1.0 bin\n'
     ret += 'timestep        %s\n' % timestep
     ret += 'thermo          ${THERMO_FREQ}\n'
-    ret += 'thermo_modify   4*8 format %20.6f\n'
     ret += 'compute         allmsd all msd\n'
     if ens == 'nvt' :        
         ret += 'thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]\n'
+        ret += 'thermo_modify   4*8 format %20.6f\n'
     elif 'npt' in ens :
         ret += 'thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]\n'
+        ret += 'thermo_modify   4*8 format %20.6f\n'
     else :
-        raise RuntimeError('unknow ensemble %s\n' % ens)                
+        raise RuntimeError('unknow ensemble %s\n' % ens) 
     ret += '# dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z\n'
     if ens == 'nvt' :
         ret += 'fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}\n'

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -83,7 +83,7 @@ def _gen_lammps_input (conf_file,
     ret += 'neighbor        1.0 bin\n'
     ret += 'timestep        %s\n' % timestep
     ret += 'thermo          ${THERMO_FREQ}\n'
-    ret += 'thermo_modify   4*8 format %20.6f
+    ret += 'thermo_modify   4*8 format %20.6f\n'
     ret += 'compute         allmsd all msd\n'
     if ens == 'nvt' :        
         ret += 'thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]\n'

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -613,7 +613,7 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms = None) :
     for ii in all_tasks :
         log_name = os.path.join(ii, 'log.lammps')
         data = get_thermo(log_name)
-        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%16.6f')
+        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%20.6f')
         block_u = []
         if path == 't' or path == 't-ginv':
             this_e = data[stat_skip::1, stat_col]

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -83,6 +83,7 @@ def _gen_lammps_input (conf_file,
     ret += 'neighbor        1.0 bin\n'
     ret += 'timestep        %s\n' % timestep
     ret += 'thermo          ${THERMO_FREQ}\n'
+    ret += 'thermo_modify   4*8 format %20.6f
     ret += 'compute         allmsd all msd\n'
     if ens == 'nvt' :        
         ret += 'thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]\n'
@@ -442,7 +443,7 @@ def post_tasks(iter_name, jdata, Eo, Eo_err = 0, To = None, natoms = None, schem
         # get energy stat
         log_name = os.path.join(ii, 'log.lammps')
         data = get_thermo(log_name)
-        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%.6e')
+        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%20.6f')
         ea, ee = block_avg(data[:, stat_col], 
                            skip = stat_skip, 
                            block_size = stat_bsize)
@@ -488,7 +489,7 @@ def post_tasks(iter_name, jdata, Eo, Eo_err = 0, To = None, natoms = None, schem
     all_print = np.array(all_print)
     np.savetxt(os.path.join(iter_name, 'ti.out'), 
                all_print.T, 
-               fmt = '%.8e', 
+               fmt = '%.12e', 
                header = 't/p Integrand U/V U/V_err enthalpy msd_xyz')
 
     info0 = _compute_thermo(os.path.join(all_tasks[ 0], 'log.lammps'), natoms, stat_skip, stat_bsize)
@@ -612,7 +613,7 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms = None) :
     for ii in all_tasks :
         log_name = os.path.join(ii, 'log.lammps')
         data = get_thermo(log_name)
-        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%.6e')
+        np.savetxt(os.path.join(ii, 'data'), data, fmt = '%16.6f')
         block_u = []
         if path == 't' or path == 't-ginv':
             this_e = data[stat_skip::1, stat_col]

--- a/tests/benchmark_gdi/deepmd/0/in.lammps
+++ b/tests/benchmark_gdi/deepmd/0/in.lammps
@@ -24,6 +24,7 @@ timestep        0.002
 thermo          ${THERMO_FREQ}
 compute         allmsd all msd
 thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+thermo_modify   4*8 format %20.6f
 # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
 fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
 fix             mzero all momentum 10 linear 1 1 1

--- a/tests/benchmark_ti/path-p/in.lammps
+++ b/tests/benchmark_ti/path-p/in.lammps
@@ -26,6 +26,7 @@ timestep        0.002
 thermo          ${THERMO_FREQ}
 compute         allmsd all msd
 thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+thermo_modify   4*8 format %20.6f
 # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
 fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} aniso ${PRES} ${PRES} ${TAU_P} couple xy
 fix             mzero all momentum 10 linear 1 1 1

--- a/tests/benchmark_ti/path-p/task.000006/in.lammps
+++ b/tests/benchmark_ti/path-p/task.000006/in.lammps
@@ -25,6 +25,7 @@ timestep        0.002
 thermo          ${THERMO_FREQ}
 compute         allmsd all msd
 thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+thermo_modify   4*8 format %20.6f
 # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
 fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} aniso ${PRES} ${PRES} ${TAU_P} couple xy
 fix             mzero all momentum 10 linear 1 1 1

--- a/tests/benchmark_ti/path-t/task.000006/in.lammps
+++ b/tests/benchmark_ti/path-t/task.000006/in.lammps
@@ -25,6 +25,7 @@ timestep        0.002
 thermo          ${THERMO_FREQ}
 compute         allmsd all msd
 thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+thermo_modify   4*8 format %20.6f
 # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
 fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} aniso ${PRES} ${PRES} ${TAU_P} couple xy
 fix             mzero all momentum 10 linear 1 1 1

--- a/tests/benchmark_ti_water/new_job/task.000003/in.lammps
+++ b/tests/benchmark_ti_water/new_job/task.000003/in.lammps
@@ -26,6 +26,7 @@ timestep        0.0005
 thermo          ${THERMO_FREQ}
 compute         allmsd all msd
 thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+thermo_modify   4*8 format %20.6f
 # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
 fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
 fix             mzero all momentum 10 linear 1 1 1

--- a/tests/test_ti_gen_lammps_input.py
+++ b/tests/test_ti_gen_lammps_input.py
@@ -58,6 +58,7 @@ class TestTiGenLammpsInput(unittest.TestCase):
         thermo          ${THERMO_FREQ}
         compute         allmsd all msd
         thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+        thermo_modify   4*8 format %20.6f
         # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
         fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
         fix             mzero all momentum 10 linear 1 1 1
@@ -117,6 +118,7 @@ class TestTiGenLammpsInput(unittest.TestCase):
         thermo          ${THERMO_FREQ}
         compute         allmsd all msd
         thermo_style    custom step ke pe etotal enthalpy temp press vol c_allmsd[*]
+        thermo_modify   4*8 format %20.6f
         # dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z
         fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
         fix             mzero all momentum 10 linear 1 1 1


### PR DESCRIPTION
change the format of lammps thermo from %.8g (lammps default, 8 significant figures) to %20.6f for concerned thermal quantities.

some systems have very large per-atom energy (lower than -1000 eV/atom)  While the reference point of the energy could be arbitary that gives even lower values, the deltaE in cared range of thermal conditions is fixed e.g. ~ several meV/atom. Storing the total energy of such systems may run out of significant figures before the cared precision.  

formats of related data-duplication output files 'data' are also changed from %.6e to %20.6f format of ti.out is also changed from %.8e in to %.12e which stores total energy too