### PR TITLE
lib/water.py: correct making bond list of water

### DIFF
--- a/dpti/lib/lmp.py
+++ b/dpti/lib/lmp.py
@@ -99,9 +99,16 @@ def get_natoms_vec(lines):
     assert sum(natoms_vec) == get_natoms(lines)
     return natoms_vec
 
-
-def get_atype(lines):
+def get_id(lines) :
     alines = get_atoms(lines)
+    idx_list = []
+    for ii in alines :
+        idx, at, x, y, z = _atom_info_atom(ii)
+        idx_list.append(idx)
+    return np.array(idx_list, dtype = int)
+
+def get_atype(lines) :
+    alines = get_atoms(lines) 
     atype = []
     for ii in alines:
         # idx, mt, at, q, x, y, z = _atom_info_mol(ii)

--- a/dpti/lib/lmp.py
+++ b/dpti/lib/lmp.py
@@ -99,16 +99,18 @@ def get_natoms_vec(lines):
     assert sum(natoms_vec) == get_natoms(lines)
     return natoms_vec
 
-def get_id(lines) :
+
+def get_id(lines):
     alines = get_atoms(lines)
     idx_list = []
-    for ii in alines :
+    for ii in alines:
         idx, at, x, y, z = _atom_info_atom(ii)
         idx_list.append(idx)
-    return np.array(idx_list, dtype = int)
+    return np.array(idx_list, dtype=int)
 
-def get_atype(lines) :
-    alines = get_atoms(lines) 
+
+def get_atype(lines):
+    alines = get_atoms(lines)
     atype = []
     for ii in alines:
         # idx, mt, at, q, x, y, z = _atom_info_mol(ii)

--- a/dpti/lib/water.py
+++ b/dpti/lib/water.py
@@ -81,8 +81,8 @@ def add_bonds(lines_, max_roh=1.3):
     natoms = lmp.get_natoms_vec(lines)
     assert len(natoms) == 2
     # type 1 == O, type 2 == H
-    assert(natoms[0] == natoms[1] // 2) 
-    
+    assert natoms[0] == natoms[1] // 2
+
     aidx = lmp.get_id(lines)
     atype = lmp.get_atype(lines)
     posis = lmp.get_posi(lines)
@@ -135,7 +135,10 @@ def add_bonds(lines_, max_roh=1.3):
     idx = 1
     for ii in range(len(bonds)):
         if atype[ii] == 1:
-            ret_ang.append("%d 1 %d %d %d" % (idx, aidx[bonds[ii][0]], aidx[ii], aidx[bonds[ii][1]]))
+            ret_ang.append(
+                "%d 1 %d %d %d"
+                % (idx, aidx[bonds[ii][0]], aidx[ii], aidx[bonds[ii][1]])
+            )
             idx += 1
 
     lines.append("Bonds")

--- a/dpti/lib/water.py
+++ b/dpti/lib/water.py
@@ -81,8 +81,9 @@ def add_bonds(lines_, max_roh=1.3):
     natoms = lmp.get_natoms_vec(lines)
     assert len(natoms) == 2
     # type 1 == O, type 2 == H
-    assert natoms[0] == natoms[1] // 2
-
+    assert(natoms[0] == natoms[1] // 2) 
+    
+    aidx = lmp.get_id(lines)
     atype = lmp.get_atype(lines)
     posis = lmp.get_posi(lines)
     bounds, tilt = lmp.get_lmpbox(lines)
@@ -125,18 +126,16 @@ def add_bonds(lines_, max_roh=1.3):
     idx = 1
     for ii in range(len(bonds)):
         if atype[ii] == 1:
-            ret_bd.append("%d 1 %d %d" % (idx, 1 + ii, 1 + bonds[ii][0]))
+            ret_bd.append("%d 1 %d %d" % (idx, aidx[ii], aidx[bonds[ii][0]]))
             idx += 1
-            ret_bd.append("%d 1 %d %d" % (idx, 1 + ii, 1 + bonds[ii][1]))
+            ret_bd.append("%d 1 %d %d" % (idx, aidx[ii], aidx[bonds[ii][1]]))
             idx += 1
 
     ret_ang = []
     idx = 1
     for ii in range(len(bonds)):
         if atype[ii] == 1:
-            ret_ang.append(
-                "%d 1 %d %d %d" % (idx, 1 + bonds[ii][0], 1 + ii, 1 + bonds[ii][1])
-            )
+            ret_ang.append("%d 1 %d %d %d" % (idx, aidx[bonds[ii][0]], aidx[ii], aidx[bonds[ii][1]]))
             idx += 1
 
     lines.append("Bonds")


### PR DESCRIPTION
The previous version only applied to the case in which the provided LAMMPS data file is written in the order of atomic id. However, this is not satisfied in most of the cases, since LAMMPS's write_data feature does not ensure sorting by atomic id. This PR makes the code correct for a general LAMMPS data file of water.