### PR TITLE
raise warning for large stat_bsize value

### DIFF
--- a/dpti/lib/utils.py
+++ b/dpti/lib/utils.py
@@ -8,6 +8,8 @@ import subprocess as sp
 
 import numpy as np
 
+import warnings
+
 iter_format = "%06d"
 task_format = "%02d"
 log_iter_head = "iter " + iter_format + " task " + task_format + ": "
@@ -123,7 +125,8 @@ def block_avg(inp, skip=0, block_size=10):
     if len(data_block) != 1:
         block_err = np.std(data_block) / np.sqrt(nblocks - 1)
     else:
-        block_err = None
+        block_err = naive_err
+        warnings.warn("We only have one block when doing the block averaging. You may be choosing a too large stat_bsize value. Make sure this is what you want.", RuntimeWarning)
 
     return block_avg, block_err
 

--- a/dpti/lib/utils.py
+++ b/dpti/lib/utils.py
@@ -5,10 +5,9 @@ import os
 import pathlib
 import shutil
 import subprocess as sp
+import warnings
 
 import numpy as np
-
-import warnings
 
 iter_format = "%06d"
 task_format = "%02d"
@@ -126,7 +125,10 @@ def block_avg(inp, skip=0, block_size=10):
         block_err = np.std(data_block) / np.sqrt(nblocks - 1)
     else:
         block_err = naive_err
-        warnings.warn("We only have one block when doing the block averaging. You may be choosing a too large stat_bsize value. Make sure this is what you want.", RuntimeWarning)
+        warnings.warn(
+            "We only have one block when doing the block averaging. You may be choosing a too large stat_bsize value. Make sure this is what you want.",
+            RuntimeWarning,
+        )
 
     return block_avg, block_err
 


### PR DESCRIPTION
This PR supports large stat_bsize value, which makes block averaging with only one block runnable. The previous implementation will raise error when there is only one block. Instead, this PR will still run the one-block averaging and raise warning for that.