### PR TITLE
change TI MD final written frame file to final.lmp

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -128,7 +128,7 @@ def _gen_lammps_input(
     ret += "velocity        all zero linear\n"
     ret += "# --------------------- RUN ------------------------------\n"
     ret += "run             ${NSTEPS}\n"
-    ret += "write_data      out.lmp\n"
+    ret += "write_data      final.lmp\n"
 
     return ret
 
@@ -940,7 +940,7 @@ def run_task(task_name, machine_file):
             command=f"ln -s ../../graph.pb graph.pb; {mdata['command']} -in in.lammps",
             task_work_path=ii,
             forward_files=["in.lammps", "*.lmp"],
-            backward_files=["log*", "out.lmp", "traj.dump"],
+            backward_files=["log*", "final.lmp", "traj.dump"],
         )
         for ii in task_dir_list
     ]

--- a/tests/benchmark_gdi/deepmd/0/in.lammps
+++ b/tests/benchmark_gdi/deepmd/0/in.lammps
@@ -34,4 +34,4 @@ velocity        all create ${TEMP} 7858
 velocity        all zero linear
 # --------------------- RUN ------------------------------
 run             ${NSTEPS}
-write_data      out.lmp
+write_data      final.lmp

--- a/tests/benchmark_ti/path-p/in.lammps
+++ b/tests/benchmark_ti/path-p/in.lammps
@@ -35,4 +35,4 @@ velocity        all create ${TEMP} 23902
 velocity        all zero linear
 # --------------------- RUN ------------------------------
 run             ${NSTEPS}
-write_data      out.lmp
+write_data      final.lmp

--- a/tests/benchmark_ti/path-p/task.000006/in.lammps
+++ b/tests/benchmark_ti/path-p/task.000006/in.lammps
@@ -35,4 +35,4 @@ velocity        all create ${TEMP} 7858
 velocity        all zero linear
 # --------------------- RUN ------------------------------
 run             ${NSTEPS}
-write_data      out.lmp
+write_data      final.lmp

--- a/tests/benchmark_ti/path-t/task.000006/in.lammps
+++ b/tests/benchmark_ti/path-t/task.000006/in.lammps
@@ -34,4 +34,4 @@ velocity        all create ${TEMP} 7858
 velocity        all zero linear
 # --------------------- RUN ------------------------------
 run             ${NSTEPS}
-write_data      out.lmp
+write_data      final.lmp

--- a/tests/benchmark_ti_water/new_job/task.000003/in.lammps
+++ b/tests/benchmark_ti_water/new_job/task.000003/in.lammps
@@ -36,4 +36,4 @@ velocity        all create ${TEMP} 7858
 velocity        all zero linear
 # --------------------- RUN ------------------------------
 run             ${NSTEPS}
-write_data      out.lmp
+write_data      final.lmp

--- a/tests/test_ti_gen_lammps_input.py
+++ b/tests/test_ti_gen_lammps_input.py
@@ -71,7 +71,7 @@ class TestTiGenLammpsInput(unittest.TestCase):
         velocity        all zero linear
         # --------------------- RUN ------------------------------
         run             ${NSTEPS}
-        write_data      out.lmp
+        write_data      final.lmp
         """
         )
         ret2 = ti._gen_lammps_input(**input)
@@ -137,7 +137,7 @@ class TestTiGenLammpsInput(unittest.TestCase):
         velocity        all zero linear
         # --------------------- RUN ------------------------------
         run             ${NSTEPS}
-        write_data      out.lmp
+        write_data      final.lmp
         """
         )
         ret2 = ti._gen_lammps_input(**input)


### PR DESCRIPTION
The last frame file written by LAMMPS was 'out.lmp', which could rewrite the original 'out.lmp', the input structure file. Therefore, I change it to 'final.lmp'.