### PR TITLE
fix dumped in.json for hti_liq

### DIFF
--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -344,11 +344,11 @@ def make_tasks(iter_name, jdata, if_meam=None):
     create_path(iter_name)
     copied_conf = os.path.join(os.path.abspath(iter_name), "conf.lmp")
     shutil.copyfile(equi_conf, copied_conf)
-    jdata['equi_conf'] = copied_conf
+    jdata["equi_conf"] = copied_conf
     if model:
         copied_model = os.path.join(os.path.abspath(iter_name), "graph.pb")
         shutil.copyfile(model, copied_model)
-    jdata['model'] = copied_model
+    jdata["model"] = copied_model
 
     cwd = os.getcwd()
     os.chdir(iter_name)

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -344,11 +344,11 @@ def make_tasks(iter_name, jdata, if_meam=None):
     create_path(iter_name)
     copied_conf = os.path.join(os.path.abspath(iter_name), "conf.lmp")
     shutil.copyfile(equi_conf, copied_conf)
-    # jdata['equi_conf'] = copied_conf
+    jdata['equi_conf'] = copied_conf
     if model:
         copied_model = os.path.join(os.path.abspath(iter_name), "graph.pb")
         shutil.copyfile(model, copied_model)
-    # jdata['model'] = copied_model
+    jdata['model'] = copied_model
 
     cwd = os.getcwd()
     os.chdir(iter_name)


### PR DESCRIPTION
Current implementation will raise error when doing `dpti hti_liq compute`. This PR fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue in the file management process to ensure that configuration and model file paths are now recorded correctly. This improvement enhances the reliability of related operations by ensuring that all necessary files are consistently and accurately referenced for future tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->