### PR TITLE
equi: write average position in out.lmp when if_dump_avg_posi=True

### DIFF
--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -131,7 +131,7 @@ def gen_equi_dump_settings(if_dump_avg_posi):
     return ret
 
 
-def gen_equi_ensemble_settings(ens):
+def gen_equi_ensemble_settings(ens, if_dump_avg_posi):
     # ens = equi_settings['ens']
     ret = ""
     if ens == "nvt":
@@ -156,6 +156,8 @@ def gen_equi_ensemble_settings(ens):
     ret += "velocity        all zero linear\n"
     ret += "# --------------------- RUN ------------------------------\n"
     ret += "run             ${NSTEPS}\n"
+    if if_dump_avg_posi:
+        ret += "read_dump     dump.avgposi ${NSTEPS} x y z\n"
     ret += "write_data      out.lmp\n"
     return ret
 
@@ -198,7 +200,7 @@ def gen_equi_lammps_input(
     )
     equi_thermo_settings = gen_equi_thermo_settings(timestep=timestep)
     equi_dump_settings = gen_equi_dump_settings(if_dump_avg_posi=if_dump_avg_posi)
-    equi_ensemble_settings = gen_equi_ensemble_settings(ens=ens)
+    equi_ensemble_settings = gen_equi_ensemble_settings(ens=ens, if_dump_avg_posi=if_dump_avg_posi)
 
     equi_lammps_input = (
         equi_header

--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -157,7 +157,10 @@ def gen_equi_ensemble_settings(ens, if_dump_avg_posi):
     ret += "# --------------------- RUN ------------------------------\n"
     ret += "run             ${NSTEPS}\n"
     if if_dump_avg_posi:
-        ret += "read_dump     dump.avgposi ${NSTEPS} x y z\n"
+        ret += "undump     fp\n"
+        ret += "undump     1\n"
+        ret += "unfix      ap\n"
+        ret += "read_dump     dump.avgposi ${NSTEPS} x y z label x f_ap[1] label y f_ap[2] label z f_ap[3]\n"
     ret += "write_data      out.lmp\n"
     return ret
 

--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -355,7 +355,6 @@ def make_task(
     ens=None,
     temp=None,
     pres=None,
-    if_dump_avg_posi=None,
     npt_dir=None,
 ):
     equi_args = [
@@ -385,7 +384,6 @@ def make_task(
         ens=ens,
         temp=temp,
         pres=pres,
-        if_dump_avg_posi=if_dump_avg_posi,
         npt_dir=npt_dir,
     )
 
@@ -674,12 +672,6 @@ def add_subparsers(module_subparsers):
         "-p", "--pressure", type=float, help="the pressure of the system"
     )
     parser_gen.add_argument(
-        "-a",
-        "--avg-posi",
-        action="store_true",
-        help="dump the average position of atoms",
-    )
-    parser_gen.add_argument(
         "-c", "--conf-npt", type=str, help="use conf computed from NPT simulation"
     )
     parser_gen.add_argument(
@@ -728,7 +720,6 @@ def handle_gen(args):
         args.ensemble,
         args.temperature,
         args.pressure,
-        args.avg_posi,
         args.conf_npt,
     )
 

--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -203,7 +203,9 @@ def gen_equi_lammps_input(
     )
     equi_thermo_settings = gen_equi_thermo_settings(timestep=timestep)
     equi_dump_settings = gen_equi_dump_settings(if_dump_avg_posi=if_dump_avg_posi)
-    equi_ensemble_settings = gen_equi_ensemble_settings(ens=ens, if_dump_avg_posi=if_dump_avg_posi)
+    equi_ensemble_settings = gen_equi_ensemble_settings(
+        ens=ens, if_dump_avg_posi=if_dump_avg_posi
+    )
 
     equi_lammps_input = (
         equi_header

--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -157,10 +157,10 @@ def gen_equi_ensemble_settings(ens, if_dump_avg_posi):
     ret += "# --------------------- RUN ------------------------------\n"
     ret += "run             ${NSTEPS}\n"
     if if_dump_avg_posi:
-        ret += "undump     fp\n"
-        ret += "undump     1\n"
-        ret += "unfix      ap\n"
-        ret += "read_dump     dump.avgposi ${NSTEPS} x y z label x f_ap[1] label y f_ap[2] label z f_ap[3]\n"
+        ret += "undump           fp\n"
+        ret += "undump           1\n"
+        ret += "unfix            ap\n"
+        ret += "read_dump        dump.avgposi ${NSTEPS} x y z label x f_ap[1] label y f_ap[2] label z f_ap[3]\n"
     ret += "write_data      out.lmp\n"
     return ret
 


### PR DESCRIPTION
When the user sets `if_dump_avg_posi=True`, write the average position in `out.lmp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined simulation ensemble configuration to improve how simulation details are managed.
  - Updated the command‐line interface by removing legacy options, resulting in a clearer and more consistent simulation setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->