### PR TITLE
Skip completed LAMMPS tasks in hti/ti run

### DIFF
--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -1409,6 +1409,22 @@ def hti_phase_trans_analyze(job, jdata=None):
     return if_phase_trans
 
 
+def _is_completed_lammps_task(task_work_path):
+    log_file = os.path.join(task_work_path, "log.lammps")
+    if not os.path.isfile(log_file):
+        return False
+    try:
+        with open(log_file, "r", errors="ignore") as fp:
+            lines = [line.strip() for line in fp if line.strip()]
+        if not lines:
+            return False
+        return lines[0].startswith("LAMMPS") and lines[-1].startswith(
+            "Total wall time"
+        )
+    except OSError:
+        return False
+
+
 def run_task(task_dir, machine_file, task_name, no_dp=False):
     if task_name == "00" or task_name == "01" or task_name == "02":
         job_work_dir_ = glob.glob(os.path.join(task_dir, task_name + "*"))
@@ -1420,6 +1436,10 @@ def run_task(task_dir, machine_file, task_name, no_dp=False):
         job_work_dir = task_dir
     task_dir_list = glob.glob(os.path.join(job_work_dir, "task*"))
     task_dir_list = sorted(task_dir_list)
+    task_dir_list = [ii for ii in task_dir_list if not _is_completed_lammps_task(ii)]
+    if len(task_dir_list) == 0:
+        print("# all tasks already completed; nothing to submit")
+        return
     work_base_dir = os.getcwd()
     with open(machine_file) as f:
         mdata = json.load(f)

--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -1414,13 +1414,11 @@ def _is_completed_lammps_task(task_work_path):
     if not os.path.isfile(log_file):
         return False
     try:
-        with open(log_file, "r", errors="ignore") as fp:
+        with open(log_file, errors="ignore") as fp:
             lines = [line.strip() for line in fp if line.strip()]
         if not lines:
             return False
-        return lines[0].startswith("LAMMPS") and lines[-1].startswith(
-            "Total wall time"
-        )
+        return lines[0].startswith("LAMMPS") and lines[-1].startswith("Total wall time")
     except OSError:
         return False
 

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -906,9 +906,29 @@ def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson"):
     return info
 
 
+def _is_completed_lammps_task(task_work_path):
+    log_file = os.path.join(task_work_path, "log.lammps")
+    if not os.path.isfile(log_file):
+        return False
+    try:
+        with open(log_file, "r", errors="ignore") as fp:
+            lines = [line.strip() for line in fp if line.strip()]
+        if not lines:
+            return False
+        return lines[0].startswith("LAMMPS") and lines[-1].startswith(
+            "Total wall time"
+        )
+    except OSError:
+        return False
+
+
 def run_task(task_name, machine_file):
     task_dir_list = glob.glob(os.path.join(task_name, "task.*"))
     task_dir_list = sorted(task_dir_list)
+    task_dir_list = [ii for ii in task_dir_list if not _is_completed_lammps_task(ii)]
+    if len(task_dir_list) == 0:
+        print("# all tasks already completed; nothing to submit")
+        return
     work_base_dir = os.getcwd()
     with open(machine_file) as f:
         mdata = json.load(f)

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -911,13 +911,11 @@ def _is_completed_lammps_task(task_work_path):
     if not os.path.isfile(log_file):
         return False
     try:
-        with open(log_file, "r", errors="ignore") as fp:
+        with open(log_file, errors="ignore") as fp:
             lines = [line.strip() for line in fp if line.strip()]
         if not lines:
             return False
-        return lines[0].startswith("LAMMPS") and lines[-1].startswith(
-            "Total wall time"
-        )
+        return lines[0].startswith("LAMMPS") and lines[-1].startswith("Total wall time")
     except OSError:
         return False
 


### PR DESCRIPTION
## Summary
- skip tasks that already have a completed log.lammps in hti.run_task
- skip tasks that already have a completed log.lammps in ti.run_task
- print a short message when nothing remains to submit

## Completion criterion
A task is treated as complete when log.lammps exists and:
- the first non-empty line starts with LAMMPS
- the last non-empty line starts with Total wall time

This avoids resubmitting tasks that have already finished successfully.
