### PR TITLE
Save hti compute output to file

### DIFF
--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -14,6 +14,7 @@ from dpdispatcher import Machine, Resources, Submission, Task
 
 from dpti.einstein import free_energy, frenkel
 from dpti.lib.lammps import get_natoms, get_thermo
+from dpti.lib.output import tee_stdout
 
 # from lib.utils import integrate_sys_err
 from dpti.lib.utils import (
@@ -1581,15 +1582,16 @@ def handle_gen(args):
 
 
 def handle_compute(args):
-    compute_task(
-        job=args.JOB,
-        free_energy_type=args.type,
-        method=args.inte_method,
-        scheme=args.scheme,
-        manual_pv=args.pv,
-        manual_pv_err=args.pv_err,
-        npt=args.npt,
-    )
+    with tee_stdout(os.path.join(args.JOB, "result.out")):
+        compute_task(
+            job=args.JOB,
+            free_energy_type=args.type,
+            method=args.inte_method,
+            scheme=args.scheme,
+            manual_pv=args.pv,
+            manual_pv_err=args.pv_err,
+            npt=args.npt,
+        )
     # if 'reference' not in jdata :
     #     jdata['reference'] = 'einstein'
 

--- a/dpti/hti_ice.py
+++ b/dpti/hti_ice.py
@@ -9,6 +9,7 @@ import scipy.constants as pc
 
 from dpti import einstein, hti
 from dpti.lib import lmp
+from dpti.lib.output import tee_stdout
 
 
 def _main():
@@ -178,7 +179,7 @@ def handle_refine(args):
     hti.refine_task(args.input, args.output, args.error, args.print)
 
 
-def handle_compute(args):
+def _handle_compute(args):
     job = args.JOB
     jdata = json.load(open(os.path.join(job, "in.json")))
     fp_conf = open(os.path.join(args.JOB, "conf.lmp"))
@@ -275,6 +276,11 @@ def handle_compute(args):
     with open(os.path.join(job, "result.json"), "w") as result:
         result.write(json.dumps(info))
     return info
+
+
+def handle_compute(args):
+    with tee_stdout(os.path.join(args.JOB, "result.out")):
+        return _handle_compute(args)
 
 
 def handle_run(args):

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -13,6 +13,7 @@ import dpti.lib.lmp as lmp
 # sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
 from dpti import einstein, hti
 from dpti.lib.lammps import get_thermo
+from dpti.lib.output import tee_stdout
 from dpti.lib.utils import (
     block_avg,
     create_path,
@@ -666,10 +667,11 @@ def handle_run(args):
 
 
 def handle_compute(args):
-    compute_task(
-        job=args.JOB,
-        free_energy_type=args.type,
-        manual_pv=args.pv,
-        manual_pv_err=args.pv_err,
-        npt=args.npt,
-    )
+    with tee_stdout(os.path.join(args.JOB, "result.out")):
+        compute_task(
+            job=args.JOB,
+            free_energy_type=args.type,
+            manual_pv=args.pv,
+            manual_pv_err=args.pv_err,
+            npt=args.npt,
+        )

--- a/dpti/hti_water.py
+++ b/dpti/hti_water.py
@@ -13,6 +13,7 @@ import scipy.constants as pc
 from dpti import einstein, hti
 from dpti.lib import lmp, water
 from dpti.lib.lammps import get_thermo
+from dpti.lib.output import tee_stdout
 
 # from lib.utils import integrate_sys_err
 from dpti.lib.utils import (
@@ -828,7 +829,7 @@ def handle_refine(args):
     refine_tasks(args.input, args.output, args.error)
 
 
-def handle_compute(args):
+def _handle_compute(args):
     job = args.JOB
     with open(os.path.join(args.JOB, "conf.lmp")) as conf_lmp:
         # fp_conf = open(os.path.join(args.JOB, 'conf.lmp'))
@@ -890,6 +891,11 @@ def handle_compute(args):
     with open(os.path.join(job, "result.json"), "w") as result:
         result.write(json.dumps(info))
     return info
+
+
+def handle_compute(args):
+    with tee_stdout(os.path.join(args.JOB, "result.out")):
+        return _handle_compute(args)
 
 
 def handle_run(args):

--- a/dpti/lib/output.py
+++ b/dpti/lib/output.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from contextlib import contextmanager
+
+
+class _Tee:
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, data):
+        for stream in self.streams:
+            stream.write(data)
+
+    def flush(self):
+        for stream in self.streams:
+            stream.flush()
+
+
+@contextmanager
+def tee_stdout(path):
+    """Write stdout to both the terminal and a file."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    old_stdout = sys.stdout
+    with open(path, "w") as fp:
+        sys.stdout = _Tee(old_stdout, fp)
+        try:
+            yield
+        finally:
+            sys.stdout = old_stdout

--- a/tests/test_lib_output.py
+++ b/tests/test_lib_output.py
@@ -1,0 +1,24 @@
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from dpti.lib.output import tee_stdout
+
+
+class TestTeeStdout(unittest.TestCase):
+    def test_tee_stdout_writes_to_stdout_and_file(self):
+        old_stdout = sys.stdout
+        captured = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "result.out"
+            try:
+                sys.stdout = captured
+                with tee_stdout(output):
+                    print("hti contribution")
+            finally:
+                sys.stdout = old_stdout
+
+            self.assertEqual(captured.getvalue(), "hti contribution\n")
+            self.assertEqual(output.read_text(), "hti contribution\n")


### PR DESCRIPTION
## Summary
- tee stdout from hti compute commands to result.out under the job directory
- apply the saved output behavior to hti, hti_liq, hti_ice, and hti_water
- add a small unit test for the stdout tee helper

## Tests
- PYTHONPATH=.:tests conda run -n dpti python -m compileall dpti tests/test_lib_output.py
- PYTHONPATH=.:tests conda run -n dpti python -m unittest tests.test_lib_output

Additional check:
- PYTHONPATH=..:. conda run -n dpti python -m unittest test_hti_ice_gen_lammps_input test_hti_water_gen_lammps_input test_hti_liq_make_task
- This ran in the dpti environment after installing the missing optional JAX module. The ice and water generation tests progressed, but the existing hti_liq make-task tests still fail because the generated LAMMPS input differs from the stored benchmark and the MEAM path raises an existing copied_model error. These failures are unrelated to saving hti compute stdout.