### PR TITLE
Avoid lambda division in hti_liq FEP integrands

### DIFF
--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -107,9 +107,7 @@ def _ff_lj_fep(ret, sparam, sign=1.0):
         for i, j in sigma_key_index:
             var_name = f"EPSILON_{i + 1}_{j + 1}"
             ret += f"variable        {var_name} equal {sign * sparam['epsilon_' + str(i) + '_' + str(j)]:f}\n"
-            fep_args.append(
-                f"pair lj/cut/soft epsilon {i + 1} {j + 1} v_{var_name}"
-            )
+            fep_args.append(f"pair lj/cut/soft epsilon {i + 1} {j + 1} v_{var_name}")
         ret += f"compute         e_diff all fep ${{TEMP}} {' '.join(fep_args)}\n"
     ret += "variable        e_diff equal c_e_diff[1]\n"
     return ret

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -89,6 +89,32 @@ def parse_lj_sigma_epsilon(ret, sparam, hybrid=False):
     return ret
 
 
+def _ff_lj_fep(ret, sparam, sign=1.0):
+    element_num = sparam.get("element_num", 1)
+    sigma_key_index = list(
+        filter(
+            lambda t: t[0] <= t[1],
+            ((i, j) for i in range(element_num) for j in range(element_num)),
+        )
+    )
+
+    epsilon = sparam.get("epsilon", None)
+    if epsilon is not None:
+        ret += f"variable        EPSILON equal {sign * epsilon:f}\n"
+        ret += "compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON\n"
+    else:
+        fep_args = []
+        for i, j in sigma_key_index:
+            var_name = f"EPSILON_{i + 1}_{j + 1}"
+            ret += f"variable        {var_name} equal {sign * sparam['epsilon_' + str(i) + '_' + str(j)]:f}\n"
+            fep_args.append(
+                f"pair lj/cut/soft epsilon {i + 1} {j + 1} v_{var_name}"
+            )
+        ret += f"compute         e_diff all fep ${{TEMP}} {' '.join(fep_args)}\n"
+    ret += "variable        e_diff equal c_e_diff[1]\n"
+    return ret
+
+
 def _ff_soft_on(lamb, sparam):
     nn = sparam["n"]
     alpha_lj = sparam["alpha_lj"]
@@ -98,8 +124,7 @@ def _ff_soft_on(lamb, sparam):
     ret = parse_lj_sigma_epsilon(ret, sparam, hybrid=False)
 
     ret += "fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes\n"
-    ret += "compute         lj_pe all pair lj/cut/soft\n"
-    ret += "variable        e_diff equal c_lj_pe/v_LAMBDA\n"
+    ret = _ff_lj_fep(ret, sparam, sign=1.0)
     return ret
 
 
@@ -148,8 +173,7 @@ def _ff_soft_off(lamb, sparam, model, if_meam=False, meam_model=None):
     ret = parse_lj_sigma_epsilon(ret, sparam, hybrid=True)
 
     ret += "fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes\n"
-    ret += "compute         lj_pe all pair lj/cut/soft\n"
-    ret += "variable        e_diff equal -c_lj_pe/v_INV_LAMBDA\n"
+    ret = _ff_lj_fep(ret, sparam, sign=-1.0)
     return ret
 
 

--- a/tests/test_hti_liq_ff_soft_on.py
+++ b/tests/test_hti_liq_ff_soft_on.py
@@ -14,11 +14,12 @@ class TestFfSpring(unittest.TestCase):
         input = {"lamb": 0.075, "sparam": soft_param}
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         pair_style      lj/cut/soft 1.000000 0.500000 6.000000
-        pair_coeff      1 1 ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes
+        variable        EPSILON equal 0.030000
         compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_on(**input)
@@ -28,29 +29,40 @@ class TestFfSpring(unittest.TestCase):
         input = {"lamb": 0.075, "sparam": soft_param_three_element}
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         pair_style      lj/cut/soft 1.000000 0.600000 6.000000
-        pair_coeff      1 1 ${EPSILON} 2.000000 0.500000
-        pair_coeff      1 2 ${EPSILON} 2.010000 0.500000
-        pair_coeff      1 3 ${EPSILON} 2.020000 0.500000
-        pair_coeff      2 2 ${EPSILON} 2.110000 0.500000
-        pair_coeff      2 3 ${EPSILON} 2.120000 0.500000
-        pair_coeff      3 3 ${EPSILON} 2.220000 0.500000
+        pair_coeff      1 1 0.030000 2.000000 0.500000
+        pair_coeff      1 2 0.030000 2.010000 0.500000
+        pair_coeff      1 3 0.030000 2.020000 0.500000
+        pair_coeff      2 2 0.030000 2.110000 0.500000
+        pair_coeff      2 3 0.030000 2.120000 0.500000
+        pair_coeff      3 3 0.030000 2.220000 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes
+        variable        EPSILON equal 0.030000
         compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_on(**input)
         self.assertEqual(ret1, ret2)
-        # print(ret2)
-        # pass
-        # input = dict(lamb=0.075, m_spring_k=[118.71],
-        #     var_spring=False)
-        # ret1 = textwrap.dedent("""\
-        # group           type_1 type 1
-        # fix             l_spring_1 type_1 spring/self 1.1871000000e+02
-        # fix_modify      l_spring_1 energy yes
-        # variable        l_spring equal f_l_spring_1
-        # """)
-        # ret2 = dpti.hti._ff_spring(**input)
-        # self.assertEqual(ret1, ret2)
+
+    def test_three_element_pair_epsilon(self):
+        sparam = dict(soft_param_three_element)
+        del sparam["epsilon"]
+        sparam.update(
+            {
+                "epsilon_0_0": 0.03,
+                "epsilon_0_1": 0.04,
+                "epsilon_0_2": 0.05,
+                "epsilon_1_1": 0.06,
+                "epsilon_1_2": 0.07,
+                "epsilon_2_2": 0.08,
+            }
+        )
+        ret = _ff_soft_on(lamb=0.075, sparam=sparam)
+        self.assertIn("variable        EPSILON_1_1 equal 0.030000\n", ret)
+        self.assertIn("variable        EPSILON_3_3 equal 0.080000\n", ret)
+        self.assertIn(
+            "compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon 1 1 v_EPSILON_1_1",
+            ret,
+        )
+        self.assertNotIn("/v_LAMBDA", ret)

--- a/tests/test_hti_liq_soft_off.py
+++ b/tests/test_hti_liq_soft_off.py
@@ -21,13 +21,13 @@ class TestSoftOff(unittest.TestCase):
         ret1 = textwrap.dedent(
             """\
         variable        INV_LAMBDA equal 1-${LAMBDA}
-        variable        EPSILON equal 0.030000
-        variable        INV_EPSILON equal -${EPSILON}
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+        variable        EPSILON equal -0.030000
+        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_off(**input)
@@ -44,18 +44,18 @@ class TestSoftOff(unittest.TestCase):
         ret1 = textwrap.dedent(
             """\
         variable        INV_LAMBDA equal 1-${LAMBDA}
-        variable        EPSILON equal 0.030000
-        variable        INV_EPSILON equal -${EPSILON}
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.600000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.000000 0.500000
-        pair_coeff      1 2 lj/cut/soft ${EPSILON} 2.010000 0.500000
-        pair_coeff      1 3 lj/cut/soft ${EPSILON} 2.020000 0.500000
-        pair_coeff      2 2 lj/cut/soft ${EPSILON} 2.110000 0.500000
-        pair_coeff      2 3 lj/cut/soft ${EPSILON} 2.120000 0.500000
-        pair_coeff      3 3 lj/cut/soft ${EPSILON} 2.220000 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.000000 0.500000
+        pair_coeff      1 2 lj/cut/soft 0.030000 2.010000 0.500000
+        pair_coeff      1 3 lj/cut/soft 0.030000 2.020000 0.500000
+        pair_coeff      2 2 lj/cut/soft 0.030000 2.110000 0.500000
+        pair_coeff      2 3 lj/cut/soft 0.030000 2.120000 0.500000
+        pair_coeff      3 3 lj/cut/soft 0.030000 2.220000 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+        variable        EPSILON equal -0.030000
+        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_off(**input)
@@ -72,13 +72,13 @@ class TestSoftOff(unittest.TestCase):
         ret1 = textwrap.dedent(
             """\
         variable        INV_LAMBDA equal 1-${LAMBDA}
-        variable        EPSILON equal 0.030000
-        variable        INV_EPSILON equal -${EPSILON}
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+        variable        EPSILON equal -0.030000
+        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_off(**input)
@@ -95,14 +95,42 @@ class TestSoftOff(unittest.TestCase):
         ret1 = textwrap.dedent(
             """\
         variable        INV_LAMBDA equal 1-${LAMBDA}
-        variable        EPSILON equal 0.030000
-        variable        INV_EPSILON equal -${EPSILON}
         pair_style      hybrid/overlay meam lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * meam library_18Metals.meam Sn Sn_18Metals.meam Sn
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+        variable        EPSILON equal -0.030000
+        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_soft_off(**input)
         self.assertEqual(ret1, ret2)
+
+    def test_three_element_pair_epsilon(self):
+        sparam = dict(soft_param_three_element)
+        del sparam["epsilon"]
+        sparam.update(
+            {
+                "epsilon_0_0": 0.03,
+                "epsilon_0_1": 0.04,
+                "epsilon_0_2": 0.05,
+                "epsilon_1_1": 0.06,
+                "epsilon_1_2": 0.07,
+                "epsilon_2_2": 0.08,
+            }
+        )
+        ret = _ff_soft_off(
+            lamb=0.075,
+            sparam=sparam,
+            model="graph.pb",
+            if_meam=False,
+            meam_model=None,
+        )
+        self.assertIn("variable        EPSILON_1_1 equal -0.030000\n", ret)
+        self.assertIn("variable        EPSILON_3_3 equal -0.080000\n", ret)
+        self.assertIn(
+            "compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon 1 1 v_EPSILON_1_1",
+            ret,
+        )
+        self.assertNotIn("/v_INV_LAMBDA", ret)


### PR DESCRIPTION
## Summary
- replace hti_liq soft-core LJ integrands that divided pair energy by LAMBDA or INV_LAMBDA with LAMMPS compute fep perturbations
- keep lambda scaling only in fix adapt/fep, matching the original FEP logic and avoiding division by zero at lambda endpoints
- preserve support for pair-specific epsilon values by emitting one compute fep perturbation per type pair when needed

## Tests
- PYTHONPATH=.:tests conda run -n dpti python -m unittest tests.test_hti_liq_ff_soft_on tests.test_hti_liq_soft_off
- PYTHONPATH=.:tests conda run -n dpti python -m compileall dpti tests/test_hti_liq_ff_soft_on.py tests/test_hti_liq_soft_off.py
- git diff --check

Additional note:
- PYTHONPATH=..:. conda run -n dpti python -m unittest from tests still reports existing failures unrelated to this change: equi tests missing the new if_dump_avg_posi argument, hti_liq deep_on/gen benchmark expectations from #88, and an existing hti_liq MEAM copied_model error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced free energy perturbation calculations with support for per-pair epsilon parameters.

* **Changes**
  * Revised Lennard-Jones energy-difference calculation methodology.
  * Updated LAMMPS script output format for FEP computations.

* **Tests**
  * Updated test expectations to match new script generation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->