### PR TITLE
Fix HTI one-step graph link path

### DIFF
--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -1425,6 +1425,14 @@ def _is_completed_lammps_task(task_work_path):
         return False
 
 
+def _graph_link_command(task_dir, job_work_dir):
+    graph_relpath = os.path.relpath(
+        os.path.join(task_dir, "graph.pb"),
+        os.path.join(job_work_dir, "task.000000"),
+    )
+    return f"ln -s {graph_relpath} graph.pb"
+
+
 def run_task(task_dir, machine_file, task_name, no_dp=False):
     if task_name == "00" or task_name == "01" or task_name == "02":
         job_work_dir_ = glob.glob(os.path.join(task_dir, task_name + "*"))
@@ -1455,7 +1463,10 @@ def run_task(task_dir, machine_file, task_name, no_dp=False):
     command = (
         f"{mdata['command']} -i in.lammps"
         if no_dp
-        else f"ln -s ../../graph.pb graph.pb; {mdata['command']} -i in.lammps"
+        else (
+            f"{_graph_link_command(task_dir, job_work_dir)}; "
+            f"{mdata['command']} -i in.lammps"
+        )
     )
     task_list = [
         Task(

--- a/tests/test_hti_make_task.py
+++ b/tests/test_hti_make_task.py
@@ -95,6 +95,16 @@ class TestHtiMakeTask(unittest.TestCase):
             f2 = os.path.join(test_dir, file)
             self.assertEqual(get_file_md5(f1), get_file_md5(f2), msg=(f1, f2))
 
+    def test_graph_link_command(self):
+        self.assertEqual(
+            dpti.hti._graph_link_command("hti", "hti"),
+            "ln -s ../graph.pb graph.pb",
+        )
+        self.assertEqual(
+            dpti.hti._graph_link_command("hti", "hti/00.deep_on"),
+            "ln -s ../../graph.pb graph.pb",
+        )
+
     @patch("numpy.random.default_rng")
     def test_meam_three_step(self, patch_random):
         patch_random.return_value = MagicMock(integers=MagicMock(return_value=7858))


### PR DESCRIPTION
This PR fixes the graph/model link path used in the HTI one-step workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the mechanism for handling graph linking during task execution for enhanced maintainability and flexibility.

* **Tests**
  * Added comprehensive unit tests to validate graph linking command generation across different task directory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->