### PR TITLE
Store HTI anchor state in result JSON

### DIFF
--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -1287,6 +1287,20 @@ def print_thermo_info(info):
     print(ptr)
 
 
+def get_npt_anchor_state(npt):
+    npt_in = json.load(open(os.path.join(npt, "jdata.json")))
+    anchor = {}
+    try:
+        anchor["t0"] = get_first_matched_key_from_dict(npt_in, ["temp", "temps"])
+    except KeyError:
+        pass
+    try:
+        anchor["p0"] = get_first_matched_key_from_dict(npt_in, ["pres", "press"])
+    except KeyError:
+        pass
+    return anchor
+
+
 def compute_task(
     job,
     free_energy_type="helmholtz",
@@ -1333,9 +1347,9 @@ def compute_task(
         e1_err = de_err[0]
     elif free_energy_type == "gibbs":
         if npt is not None:
-            npt_in = json.load(open(os.path.join(npt, "jdata.json")))
             npt_info = json.load(open(os.path.join(npt, "result.json")))
-            p = npt_in["pres"]
+            anchor = get_npt_anchor_state(npt)
+            p = anchor["p0"]
             v = npt_info["v"]
             v_err = npt_info["v_err"]
             unit_cvt = 1e5 * (1e-10**3) / pc.electron_volt
@@ -1360,6 +1374,8 @@ def compute_task(
         raise RuntimeError("unknown free energy type")
 
     info["free_energy_type"] = free_energy_type
+    if npt is not None:
+        info.update(get_npt_anchor_state(npt))
     info["e0"] = e0
     info["pv"] = pv
     info["pv_err"] = pv_err

--- a/dpti/hti_ice.py
+++ b/dpti/hti_ice.py
@@ -240,9 +240,9 @@ def _handle_compute(args):
         e1_err = de_err[0]
     elif args.type == "gibbs":
         if args.npt is not None:
-            npt_in = json.load(open(os.path.join(args.npt, "jdata.json")))
             npt_info = json.load(open(os.path.join(args.npt, "result.json")))
-            p = npt_in["pres"]
+            anchor = hti.get_npt_anchor_state(args.npt)
+            p = anchor["p0"]
             v = npt_info["v"]
             v_err = npt_info["v_err"]
             unit_cvt = 1e5 * (1e-10**3) / pc.electron_volt
@@ -269,6 +269,8 @@ def _handle_compute(args):
         raise RuntimeError("unknown free energy type")
     free_energy_type = args.type
     info["free_energy_type"] = free_energy_type
+    if args.npt is not None:
+        info.update(hti.get_npt_anchor_state(args.npt))
     # info['de'] = de
     # info['de_err'] = de_err
     info["e1"] = e1

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -549,9 +549,9 @@ def compute_task(
         e1_err = fe_err[0]
     elif free_energy_type == "gibbs":
         if npt is not None:
-            npt_in = json.load(open(os.path.join(npt, "jdata.json")))
             npt_info = json.load(open(os.path.join(npt, "result.json")))
-            p = npt_in["pres"]
+            anchor = hti.get_npt_anchor_state(npt)
+            p = anchor["p0"]
             v = npt_info["v"]
             v_err = npt_info["v_err"]
             unit_cvt = 1e5 * (1e-10**3) / pc.electron_volt
@@ -576,6 +576,8 @@ def compute_task(
         raise RuntimeError("unknown free energy type")
 
     info["free_energy_type"] = free_energy_type
+    if npt is not None:
+        info.update(hti.get_npt_anchor_state(npt))
     info["pv"] = pv
     info["pv_err"] = pv_err
     # info['de'] = de

--- a/dpti/hti_water.py
+++ b/dpti/hti_water.py
@@ -855,9 +855,9 @@ def _handle_compute(args):
         e1_err = fe_err[0]
     elif args.type == "gibbs":
         if args.npt is not None:
-            npt_in = json.load(open(os.path.join(args.npt, "jdata.json")))
             npt_info = json.load(open(os.path.join(args.npt, "result.json")))
-            p = npt_in["pres"]
+            anchor = hti.get_npt_anchor_state(args.npt)
+            p = anchor["p0"]
             v = npt_info["v"]
             v_err = npt_info["v_err"]
             unit_cvt = 1e5 * (1e-10**3) / pc.electron_volt
@@ -884,6 +884,8 @@ def _handle_compute(args):
         raise RuntimeError("known free energy type")
     free_energy_type = args.type
     info["free_energy_type"] = free_energy_type
+    if args.npt is not None:
+        info.update(hti.get_npt_anchor_state(args.npt))
     # info['de'] = de
     # info['de_err'] = de_err
     info["e1"] = e1

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -905,6 +905,30 @@ def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson"):
     return info
 
 
+def _get_hti_anchor_position(path, jdata_hti, jdata_hti_in):
+    if path == "t" or path == "t-ginv":
+        to = jdata_hti.get("t0", jdata_hti_in.get("temp"))
+        if to is None:
+            raise ValueError(
+                "Cannot find temperature in hti's result or input json file"
+            )
+        return to
+    if path == "p":
+        try:
+            return get_first_matched_key_from_dict(
+                jdata_hti, ["p0", "pres", "press"]
+            )
+        except KeyError:
+            pass
+        try:
+            return get_first_matched_key_from_dict(jdata_hti_in, ["pres", "press"])
+        except KeyError:
+            raise ValueError(
+                "Cannot find pressure in hti's result or input json file"
+            )
+    return None
+
+
 def _is_completed_lammps_task(task_work_path):
     log_file = os.path.join(task_work_path, "log.lammps")
     if not os.path.isfile(log_file):
@@ -1060,19 +1084,7 @@ def handle_compute(args):
     if args.Eo_err is None:
         args.Eo_err = jdata_hti["e1_err"]
     if args.To is None:
-        if path == "t" or path == "t-ginv":
-            args.To = jdata_hti_in["temp"]
-            if args.To is None:
-                raise ValueError("Cannot find temperature in hti's input json file")
-        elif path == "p":
-            try:
-                args.To = get_first_matched_key_from_dict(
-                    jdata_hti_in, ["pres", "press"]
-                )
-            except KeyError:
-                args.To = None
-            if args.To is None:
-                raise ValueError("Cannot find pressure in hti's input json file")
+        args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
     compute_task(
         args.JOB,
         inte_method=args.inte_method,

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -915,17 +915,13 @@ def _get_hti_anchor_position(path, jdata_hti, jdata_hti_in):
         return to
     if path == "p":
         try:
-            return get_first_matched_key_from_dict(
-                jdata_hti, ["p0", "pres", "press"]
-            )
+            return get_first_matched_key_from_dict(jdata_hti, ["p0", "pres", "press"])
         except KeyError:
             pass
         try:
             return get_first_matched_key_from_dict(jdata_hti_in, ["pres", "press"])
         except KeyError:
-            raise ValueError(
-                "Cannot find pressure in hti's result or input json file"
-            )
+            raise ValueError("Cannot find pressure in hti's result or input json file")
     return None
 
 

--- a/dpti/ti_water.py
+++ b/dpti/ti_water.py
@@ -134,6 +134,10 @@ def handle_gen(args):
     ti.make_tasks(output, jdata)
 
 
+def _get_hti_anchor_position(path, jdata_hti, jdata_hti_in):
+    return ti._get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
+
+
 def handle_compute(args):
     job = args.JOB
     jdata = json.load(open(os.path.join(job, "ti_settings.json")))
@@ -155,10 +159,7 @@ def handle_compute(args):
     if args.Eo_err is None:
         args.Eo_err = jdata_hti["e1_err"]
     if args.To is None:
-        if path == "t" or path == "t-ginv":
-            args.To = jdata_hti_in["temp"]
-        elif path == "p":
-            args.To = jdata_hti_in["pres"]
+        args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
     if args.inte_method == "inte":
         ti.post_tasks(
             job,

--- a/tests/test_hti_anchor_state.py
+++ b/tests/test_hti_anchor_state.py
@@ -1,0 +1,54 @@
+import json
+import shutil
+import unittest
+from pathlib import Path
+
+from context import dpti
+
+
+class TestHtiAnchorState(unittest.TestCase):
+    def setUp(self):
+        self.work_dir = Path("tmp_hti_anchor")
+        if self.work_dir.exists():
+            shutil.rmtree(self.work_dir)
+        self.work_dir.mkdir()
+
+    def tearDown(self):
+        if self.work_dir.exists():
+            shutil.rmtree(self.work_dir)
+
+    def test_get_npt_anchor_state(self):
+        npt = self.work_dir / "npt"
+        npt.mkdir()
+        (npt / "jdata.json").write_text(json.dumps({"temp": 1600, "pres": 50000}))
+
+        anchor = dpti.hti.get_npt_anchor_state(str(npt))
+
+        self.assertEqual(anchor["t0"], 1600)
+        self.assertEqual(anchor["p0"], 50000)
+
+    def test_ti_prefers_anchor_position_from_hti_result(self):
+        hti_result = {"t0": 1600, "p0": 50000}
+        hti_input = {"temp": 1500, "pres": 10000}
+
+        self.assertEqual(
+            dpti.ti._get_hti_anchor_position("t", hti_result, hti_input), 1600
+        )
+        self.assertEqual(
+            dpti.ti._get_hti_anchor_position("p", hti_result, hti_input), 50000
+        )
+
+    def test_ti_falls_back_to_hti_input_for_old_results(self):
+        hti_result = {}
+        hti_input = {"temp": 1500, "pres": 10000}
+
+        self.assertEqual(
+            dpti.ti._get_hti_anchor_position("t", hti_result, hti_input), 1500
+        )
+        self.assertEqual(
+            dpti.ti._get_hti_anchor_position("p", hti_result, hti_input), 10000
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hti_anchor_state.py
+++ b/tests/test_hti_anchor_state.py
@@ -37,6 +37,12 @@ class TestHtiAnchorState(unittest.TestCase):
         self.assertEqual(
             dpti.ti._get_hti_anchor_position("p", hti_result, hti_input), 50000
         )
+        self.assertEqual(
+            dpti.ti_water._get_hti_anchor_position("t", hti_result, hti_input), 1600
+        )
+        self.assertEqual(
+            dpti.ti_water._get_hti_anchor_position("p", hti_result, hti_input), 50000
+        )
 
     def test_ti_falls_back_to_hti_input_for_old_results(self):
         hti_result = {}
@@ -47,6 +53,12 @@ class TestHtiAnchorState(unittest.TestCase):
         )
         self.assertEqual(
             dpti.ti._get_hti_anchor_position("p", hti_result, hti_input), 10000
+        )
+        self.assertEqual(
+            dpti.ti_water._get_hti_anchor_position("t", hti_result, hti_input), 1500
+        )
+        self.assertEqual(
+            dpti.ti_water._get_hti_anchor_position("p", hti_result, hti_input), 10000
         )
 
 


### PR DESCRIPTION
## Summary
- Write HTI anchor temperature/pressure (`t0`/`p0`) to `result.json` when Gibbs free energies are computed with `--npt`.
- Make `ti compute -H` prefer the anchor state from HTI `result.json`, with fallback to `in.json` for older results.
- Apply the anchor metadata consistently across atomic solid/liquid, ice, and water HTI frontends.

## Tests
- `conda run -n dpti python -m pytest tests/test_hti_anchor_state.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved NPT (pressure-temperature) anchor state handling in Gibbs free energy calculations.
  * Results now include NPT anchor state metadata for better data traceability and consistency.
  * Centralized pressure and temperature extraction from NPT reference simulations across all computation types.

* **Tests**
  * Added validation tests for NPT anchor state extraction and computation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->