### PR TITLE
Expose HTI refine commands

### DIFF
--- a/dpti/hti.py
+++ b/dpti/hti.py
@@ -29,6 +29,28 @@ from dpti.lib.utils import (
 )
 
 
+def format_refine_summary(all_lambda, interval_nrefine, source_task=None):
+    lines = []
+    if source_task is not None:
+        lines.append(f"# original task: {os.path.abspath(source_task)}")
+    lines.append("# refinement plan")
+    lines.append("# interval  lambda_left      lambda_right     nrefine  nnew")
+    total_new_points = 0
+    for idx, nrefine in enumerate(interval_nrefine):
+        nnew = max(nrefine - 1, 0)
+        total_new_points += nnew
+        lines.append(
+            f"{idx:10d}  {all_lambda[idx]:15.8e}  {all_lambda[idx + 1]:15.8e}"
+            f"  {nrefine:7d}  {nnew:4d}"
+        )
+    lines.append(f"# total new points: {total_new_points}")
+    return "\n".join(lines)
+
+
+def print_refine_summary(all_lambda, interval_nrefine, source_task=None):
+    print(format_refine_summary(all_lambda, interval_nrefine, source_task))
+
+
 def make_iter_name(iter_index):
     return "task_hti." + ("%04d" % iter_index)
 
@@ -851,9 +873,12 @@ def refine_task(
     ntask = all_t.size
 
     interval_nrefine = compute_nrefine(all_t, integrand, err)
+    refine_summary = format_refine_summary(
+        all_t, interval_nrefine, source_task=from_task
+    )
+    print(refine_summary)
     if print_ref:
-        print(interval_nrefine)
-        return
+        return refine_summary
 
     refined_t = []
     back_map = []
@@ -872,14 +897,41 @@ def refine_task(
     from_jdata = json.load(open(from_json))
     to_jdata = from_jdata
 
-    to_jdata["lambda"] = refined_t
+    switch = to_jdata.get("switch", "one-step")
+    step = to_jdata.get("step", "both")
+    if switch == "one-step" or step == "both":
+        to_jdata["lambda"] = refined_t
+    elif step == "deep_on":
+        to_jdata["lambda_deep_on"] = refined_t
+        to_jdata["lambda_deep_on_back_map"] = back_map
+    elif step == "spring_off":
+        to_jdata["lambda_spring_off"] = refined_t
+        to_jdata["lambda_spring_off_back_map"] = back_map
+    elif step == "lj_on":
+        to_jdata["lambda_lj_on"] = refined_t
+        to_jdata["lambda_lj_on_back_map"] = back_map
+    else:
+        raise RuntimeError(f"unknown HTI refinement step {step}")
     to_jdata["orig_task"] = from_task
     to_jdata["back_map"] = back_map
     to_jdata["refine_error"] = err
     to_jdata["equi_conf"] = get_task_file_abspath(from_task, from_jdata["equi_conf"])
     to_jdata["model"] = get_task_file_abspath(from_task, from_jdata["model"])
 
-    make_tasks(to_task, to_jdata, to_jdata["reference"], if_meam=if_meam)
+    if switch == "one-step" or step == "both":
+        make_tasks(to_task, to_jdata, to_jdata["reference"], if_meam=if_meam)
+    else:
+        _make_tasks(
+            to_task,
+            to_jdata,
+            to_jdata["reference"],
+            switch=switch,
+            step=step,
+            if_meam=if_meam,
+            meam_model=meam_model,
+        )
+    with open(os.path.join(to_task, "refine.out"), "w") as fp:
+        fp.write(refine_summary + "\n")
 
     from_task_list = glob.glob(os.path.join(from_task, "task.[0-9]*"))
     from_task_list.sort()
@@ -898,6 +950,7 @@ def refine_task(
             )
         with open(os.path.join(to_task_list[ii], "from.dir"), "w") as fp:
             fp.write(from_task_list[back_map[ii]])
+    return refine_summary
 
 
 def _compute_thermo(fname, natoms, stat_skip, stat_bsize):
@@ -1583,6 +1636,23 @@ def add_module_subparsers(main_subparsers):
     )
     parser_compute.set_defaults(func=handle_compute)
 
+    parser_refine = module_subparsers.add_parser(
+        "refine", help="Refine the grid of a job"
+    )
+    parser_refine.add_argument(
+        "-i", "--input", type=str, required=True, help="input job"
+    )
+    parser_refine.add_argument(
+        "-o", "--output", type=str, required=True, help="output job"
+    )
+    parser_refine.add_argument(
+        "-e", "--error", type=float, required=True, help="the error required"
+    )
+    parser_refine.add_argument(
+        "-p", "--print", action="store_true", help="print the refinement and exit"
+    )
+    parser_refine.set_defaults(func=handle_refine)
+
     parser_run = module_subparsers.add_parser("run", help="run the job")
     parser_run.add_argument("JOB", type=str, help="folder of the job")
     parser_run.add_argument("machine", type=str, help="machine.json file for the job")
@@ -1622,6 +1692,10 @@ def handle_compute(args):
         )
     # if 'reference' not in jdata :
     #     jdata['reference'] = 'einstein'
+
+
+def handle_refine(args):
+    refine_task(args.input, args.output, args.error, args.print)
 
 
 def handle_run(args):

--- a/dpti/hti_ice.py
+++ b/dpti/hti_ice.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import shutil
 
 import numpy as np
 import scipy.constants as pc
@@ -175,8 +176,77 @@ def handle_gen(args):
     hti.make_tasks(output, jdata, "einstein", args.switch)
 
 
+def _detect_switch(job, jdata):
+    switch = jdata.get("switch", None)
+    if switch is not None:
+        return switch
+    if os.path.isdir(os.path.join(job, "00.lj_on")):
+        return "three-step"
+    if os.path.isdir(os.path.join(job, "00.deep_on")):
+        return "two-step"
+    return "one-step"
+
+
+def refine_tasks(from_task, to_task, err, print_ref=False):
+    from_task = os.path.abspath(from_task)
+    to_task = os.path.abspath(to_task)
+    with open(os.path.join(from_task, "in.json")) as fp:
+        jdata = json.load(fp)
+
+    switch = _detect_switch(from_task, jdata)
+    if switch == "one-step":
+        hti.refine_task(from_task, to_task, err, print_ref)
+        return
+
+    if switch == "two-step":
+        stage_names = ["00.deep_on", "01.spring_off"]
+    elif switch == "three-step":
+        stage_names = ["00.lj_on", "01.deep_on", "02.spring_off"]
+    else:
+        raise RuntimeError(f"unknown HTI switch {switch}")
+
+    if print_ref:
+        for stage_name in stage_names:
+            print(f"# {stage_name}")
+            hti.refine_task(
+                os.path.join(from_task, stage_name),
+                os.path.join(to_task, stage_name),
+                err,
+                print_ref=True,
+            )
+        return
+
+    equi_conf = hti.get_task_file_abspath(from_task, jdata["equi_conf"])
+    model = hti.get_task_file_abspath(from_task, jdata["model"])
+
+    hti.create_path(to_task)
+    shutil.copyfile(equi_conf, os.path.join(to_task, "conf.lmp"))
+    jdata["equi_conf"] = "conf.lmp"
+    shutil.copyfile(model, os.path.join(to_task, "graph.pb"))
+    jdata["model"] = "graph.pb"
+    jdata["switch"] = switch
+    jdata["orig_task"] = from_task
+    jdata["refine_error"] = err
+
+    with open(os.path.join(to_task, "in.json"), "w") as fp:
+        json.dump(jdata, fp, indent=4)
+
+    refine_summaries = []
+    for stage_name in stage_names:
+        print(f"# {stage_name}")
+        refine_summary = hti.refine_task(
+            os.path.join(from_task, stage_name),
+            os.path.join(to_task, stage_name),
+            err,
+        )
+        refine_summaries.append(f"# {stage_name}\n{refine_summary}")
+
+    with open(os.path.join(to_task, "refine.out"), "w") as fp:
+        fp.write("\n".join(refine_summaries) + "\n")
+
+
 def handle_refine(args):
-    hti.refine_task(args.input, args.output, args.error, args.print)
+    refine_tasks(args.input, args.output, args.error, args.print)
 
 
 def _handle_compute(args):

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -16,6 +16,7 @@ from dpti.lib.lammps import get_thermo
 from dpti.lib.output import tee_stdout
 from dpti.lib.utils import (
     block_avg,
+    compute_nrefine,
     create_path,
     get_first_matched_key_from_dict,
     integrate,
@@ -506,6 +507,109 @@ def post_tasks(iter_name, natoms):
     return fe, [err, sys_err], tinfo2
 
 
+def _refinement_from_stage(from_task, err):
+    from_task = os.path.abspath(from_task)
+    from_ti = os.path.join(from_task, "hti.out")
+    if not os.path.isfile(from_ti):
+        raise RuntimeError(
+            f"cannot find file {from_ti}, task should be computed befor refined"
+        )
+    tmp_array = np.loadtxt(from_ti)
+    all_t = tmp_array[:, 0]
+    integrand = tmp_array[:, 1]
+    ntask = all_t.size
+
+    interval_nrefine = compute_nrefine(all_t, integrand, err)
+    refined_t = []
+    back_map = []
+    for ii in range(0, ntask - 1):
+        refined_t.append(all_t[ii])
+        back_map.append(ii)
+        hh = (all_t[ii + 1] - all_t[ii]) / interval_nrefine[ii]
+        for jj in range(1, interval_nrefine[ii]):
+            refined_t.append(all_t[ii] + jj * hh)
+            back_map.append(-1)
+    refined_t.append(all_t[-1])
+    back_map.append(ntask - 1)
+    return all_t, interval_nrefine, refined_t, back_map
+
+
+def refine_tasks(from_task, to_task, err, print_ref=False):
+    from_task = os.path.abspath(from_task)
+    to_task = os.path.abspath(to_task)
+    with open(os.path.join(from_task, "in.json")) as fp:
+        jdata = json.load(fp)
+
+    stage_specs = [
+        ("00.soft_on", "soft_on", "lambda_soft_on"),
+        ("01.deep_on", "deep_on", "lambda_deep_on"),
+        ("02.soft_off", "soft_off", "lambda_soft_off"),
+    ]
+    stage_refinements = {}
+    refine_summaries = []
+    for stage_name, step, lambda_key in stage_specs:
+        stage_task = os.path.join(from_task, stage_name)
+        all_t, interval_nrefine, refined_t, back_map = _refinement_from_stage(
+            stage_task, err
+        )
+        print(f"# {stage_name}")
+        refine_summary = hti.format_refine_summary(
+            all_t, interval_nrefine, source_task=stage_task
+        )
+        print(refine_summary)
+        refine_summaries.append(f"# {stage_name}\n{refine_summary}")
+        stage_refinements[stage_name] = (refined_t, back_map)
+        jdata[lambda_key] = refined_t
+        jdata[f"{lambda_key}_back_map"] = back_map
+
+    if print_ref:
+        return
+
+    equi_conf = hti.get_task_file_abspath(from_task, jdata["equi_conf"])
+    model = hti.get_task_file_abspath(from_task, jdata["model"])
+    if_meam = jdata.get("if_meam", False)
+    meam_model = jdata.get("meam_model", None)
+
+    create_path(to_task)
+    shutil.copyfile(equi_conf, os.path.join(to_task, "conf.lmp"))
+    jdata["equi_conf"] = "conf.lmp"
+    shutil.copyfile(model, os.path.join(to_task, "graph.pb"))
+    jdata["model"] = "graph.pb"
+    jdata["orig_task"] = from_task
+    jdata["refine_error"] = err
+
+    with open(os.path.join(to_task, "in.json"), "w") as fp:
+        json.dump(jdata, fp, indent=4)
+    with open(os.path.join(to_task, "refine.out"), "w") as fp:
+        fp.write("\n".join(refine_summaries) + "\n")
+
+    for stage_name, step, _ in stage_specs:
+        _make_tasks(
+            os.path.join(to_task, stage_name),
+            jdata,
+            step,
+            if_meam=if_meam,
+            meam_model=meam_model,
+        )
+
+        refined_t, back_map = stage_refinements[stage_name]
+        from_task_list = glob.glob(os.path.join(from_task, stage_name, "task.[0-9]*"))
+        from_task_list.sort()
+        to_task_list = glob.glob(os.path.join(to_task, stage_name, "task.[0-9]*"))
+        to_task_list.sort()
+        assert len(to_task_list) == len(refined_t)
+        for ii in range(len(to_task_list)):
+            if back_map[ii] < 0:
+                continue
+            for jj in ["data", "log.lammps"]:
+                shutil.copyfile(
+                    os.path.join(from_task_list[back_map[ii]], jj),
+                    os.path.join(to_task_list[ii], jj),
+                )
+            with open(os.path.join(to_task_list[ii], "from.dir"), "w") as fp:
+                fp.write(from_task_list[back_map[ii]])
+
+
 def _print_thermo_info(info):
     ptr = "# thermodynamics (normalized by natoms)\n"
     ptr += "# E (err)  [eV]:  {:20.8f} {:20.8f}\n".format(info["e"], info["e_err"])
@@ -643,6 +747,23 @@ def add_module_subparsers(main_subparsers):
     )
     parser_compute.set_defaults(func=handle_compute)
 
+    parser_refine = module_subparsers.add_parser(
+        "refine", help="Refine the grid of a job"
+    )
+    parser_refine.add_argument(
+        "-i", "--input", type=str, required=True, help="input job"
+    )
+    parser_refine.add_argument(
+        "-o", "--output", type=str, required=True, help="output job"
+    )
+    parser_refine.add_argument(
+        "-e", "--error", type=float, required=True, help="the error required"
+    )
+    parser_refine.add_argument(
+        "-p", "--print", action="store_true", help="print the refinement and exit"
+    )
+    parser_refine.set_defaults(func=handle_refine)
+
     parser_run = module_subparsers.add_parser("run", help="run the job")
     parser_run.add_argument("JOB", type=str, help="folder of the job")
     parser_run.add_argument("machine", type=str, help="machine.json file for the job")
@@ -701,3 +822,7 @@ def handle_compute(args):
             manual_pv_err=args.pv_err,
             npt=args.npt,
         )
+
+
+def handle_refine(args):
+    refine_tasks(args.input, args.output, args.error, args.print)


### PR DESCRIPTION
## Summary
- expose the existing atomic-solid HTI refine helper through `dpti hti refine`
- make `dpti hti_ice refine` refine two-step and three-step jobs stage by stage
- add `dpti hti_liq refine` for the soft-on, deep-on, and soft-off stages
- make refinement output show a readable table with the original absolute task path, interval endpoints, `nrefine`, number of new points, and total new points
- print the same refinement plan both in preview mode and when generating refined tasks
- save the refinement plan to `refine.out` in the output job directory when generating tasks

## Tests
- `python -m compileall -q dpti/hti.py dpti/hti_ice.py dpti/hti_liq.py`
- `PYTHONPATH=$PWD conda run -n dpti python -m dpti.main hti -h`
- `PYTHONPATH=$PWD conda run -n dpti python -m dpti.main hti_liq -h`
- `PYTHONPATH=$PWD conda run -n dpti python -m dpti.main hti_ice -h`
- temporary smoke tests for `hti_ice refine --print` and `hti_liq refine --print`
- temporary generation test for `hti_ice refine` without `--print`, including root and stage `refine.out` files
