### PR TITLE
feat: organize TI compute outputs by HTI anchor

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -11,6 +11,7 @@ import scipy.constants as pc
 from dpdispatcher import Machine, Resources, Submission, Task
 
 from dpti.lib.lammps import get_natoms, get_thermo
+from dpti.lib.output import tee_stdout
 
 # sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
 # from lib.utils import integrate_sys_err
@@ -550,8 +551,11 @@ def post_tasks(
     all_print.append(all_enthalpy)
     all_print.append(all_msd_xyz)
     all_print = np.array(all_print)
+    if output_dir is None:
+        output_dir = iter_name
+
     np.savetxt(
-        os.path.join(iter_name, "ti.out"),
+        os.path.join(output_dir, "ti.out"),
         all_print.T,
         fmt="%.12e",
         header="t/p Integrand U/V U/V_err enthalpy msd_xyz",
@@ -676,14 +680,14 @@ def post_tasks(
     #     np.linalg.norm([all_fe_err[ii], all_fe_sys_err[ii]]).tolist()]
     info = {"start_point_info": info0, "end_point_info": info1, "data": data}
     # print('result', result)
-    with open(os.path.join(iter_name, "../", "result"), "w") as f:
+    with open(os.path.join(output_dir, "result"), "w") as f:
         f.write(result)
-    with open(os.path.join(iter_name, "result.json"), "w") as f:
+    with open(os.path.join(output_dir, "result.json"), "w") as f:
         f.write(json.dumps(info))
     return info
 
 
-def post_tasks_mbar(iter_name, jdata, Eo, natoms=None):
+def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None):
     equi_conf = jdata["equi_conf"]
     if natoms is None:
         natoms = get_natoms(equi_conf)
@@ -795,25 +799,41 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms=None):
         all_fe_err.append(err)
         all_fe_sys_err.append(sys_err)
 
+    result = ""
     if "nvt" == ens:
         print("#%8s  %15s  %9s  %9s" % ("T(ctrl)", "F", "stat_err", "inte_err"))
+        result += "#%8s  %15s  %9s  %9s\n" % ("T(ctrl)", "F", "stat_err", "inte_err")
         for ii in range(len(all_temps)):
-            print(
-                f"{all_temps[ii]:9.2f}  {all_fe[ii]:20.12f}  {all_fe_err[ii]:9.2e}  {all_fe_sys_err[ii]:9.2e}"
-            )
+            line = f"{all_temps[ii]:9.2f}  {all_fe[ii]:20.12f}  {all_fe_err[ii]:9.2e}  {all_fe_sys_err[ii]:9.2e}"
+            print(line)
+            result += line + "\n"
     elif "npt" in ens:
         print(
             "#%8s  %15s  %15s  %9s  %9s"
             % ("T(ctrl)", "P(ctrl)", "F", "stat_err", "inte_err")
         )
+        result += "#%8s  %15s  %15s  %9s  %9s\n" % ("T(ctrl)", "P(ctrl)", "F", "stat_err", "inte_err")
         for ii in range(len(all_temps)):
-            print(
-                f"{all_temps[ii]:9.2f}  {all_press[ii]:15.8e}  {all_fe[ii]:20.12f}  {all_fe_err[ii]:9.2e}  {all_fe_sys_err[ii]:9.2e}"
-            )
-    # info = dict(start_point_info=info0, end_point_info=info1, all_temps=list(all_temps), all_press=list(all_press),
-    #              all_fe=list(all_fe), all_fe_err=list(all_fe_err), all_fe_sys_err=list(all_fe_sys_err))
-    # open(os.path.join(iter_name, 'result.json'), 'w').write(json.dumps(info))
-    # return info
+            line = f"{all_temps[ii]:9.2f}  {all_press[ii]:15.8e}  {all_fe[ii]:20.12f}  {all_fe_err[ii]:9.2e}  {all_fe_sys_err[ii]:9.2e}"
+            print(line)
+            result += line + "\n"
+
+    if output_dir is None:
+        output_dir = iter_name
+    data = {
+        "all_temps": list(all_temps),
+        "all_press": list(all_press),
+        "all_fe": list(all_fe),
+        "all_fe_stat_err": list(all_fe_err),
+        "all_fe_inte_err": list(all_fe_sys_err),
+        "all_fe_tot_err": list(np.linalg.norm(np.vstack([all_fe_err, all_fe_sys_err]), axis=0)),
+    }
+    info = {"start_point_info": info0, "end_point_info": info1, "data": data}
+    with open(os.path.join(output_dir, "result"), "w") as f:
+        f.write(result)
+    with open(os.path.join(output_dir, "result.json"), "w") as f:
+        f.write(json.dumps(info))
+    return info
 
 
 def refine_task(from_task, to_task, err):
@@ -892,14 +912,22 @@ def refine_task(from_task, to_task, err):
             fp.write(from_task_list[back_map[ii]])
 
 
-def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson"):
+def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson", output_dir=None):
     # job = args.JOB
     with open(os.path.join(job, "ti_settings.json")) as f:
         jdata = json.load(f)
     if inte_method == "inte":
-        info = post_tasks(job, jdata, Eo=Eo, Eo_err=Eo_err, To=To, scheme=scheme)
+        info = post_tasks(
+            job,
+            jdata,
+            Eo=Eo,
+            Eo_err=Eo_err,
+            To=To,
+            scheme=scheme,
+            output_dir=output_dir,
+        )
     elif inte_method == "mbar":
-        info = post_tasks_mbar(job, jdata, Eo)
+        info = post_tasks_mbar(job, jdata, Eo, output_dir=output_dir)
     else:
         raise RuntimeError("unknow integration method")
     return info
@@ -1069,26 +1097,35 @@ def handle_compute(args):
     jdata = json.load(open(os.path.join(job, "ti_settings.json")))
     path = jdata["path"]
     hti_dir = args.hti
-    jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
-    jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
-    if args.Eo is not None and args.hti is not None:
-        raise ValueError(
-            "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."
+    output_dir = args.JOB
+    if hti_dir is not None:
+        hti_dir = os.path.normpath(hti_dir)
+        hti_name = os.path.basename(hti_dir)
+        output_dir = os.path.join(args.JOB, hti_name)
+        create_path(output_dir)
+        jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
+        jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
+        if args.Eo is not None and args.hti is not None:
+            raise ValueError(
+                "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."
+            )
+        if args.Eo is None:
+            args.Eo = jdata_hti["e1"]
+        if args.Eo_err is None:
+            args.Eo_err = jdata_hti["e1_err"]
+        if args.To is None:
+            args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
+
+    with tee_stdout(os.path.join(output_dir, "result.out")):
+        compute_task(
+            args.JOB,
+            inte_method=args.inte_method,
+            Eo=args.Eo,
+            Eo_err=args.Eo_err,
+            To=args.To,
+            scheme=args.scheme,
+            output_dir=output_dir,
         )
-    if args.Eo is None:
-        args.Eo = jdata_hti["e1"]
-    if args.Eo_err is None:
-        args.Eo_err = jdata_hti["e1_err"]
-    if args.To is None:
-        args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
-    compute_task(
-        args.JOB,
-        inte_method=args.inte_method,
-        Eo=args.Eo,
-        Eo_err=args.Eo_err,
-        To=args.To,
-        scheme=args.scheme,
-    )
     #     job = args.JOB
     #     jdata = json.load(open(os.path.join(job, 'in.json'), 'r'))
     #     if args.inte_method == 'inte' :

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -812,7 +812,13 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None):
             "#%8s  %15s  %15s  %9s  %9s"
             % ("T(ctrl)", "P(ctrl)", "F", "stat_err", "inte_err")
         )
-        result += "#%8s  %15s  %15s  %9s  %9s\n" % ("T(ctrl)", "P(ctrl)", "F", "stat_err", "inte_err")
+        result += "#%8s  %15s  %15s  %9s  %9s\n" % (
+            "T(ctrl)",
+            "P(ctrl)",
+            "F",
+            "stat_err",
+            "inte_err",
+        )
         for ii in range(len(all_temps)):
             line = f"{all_temps[ii]:9.2f}  {all_press[ii]:15.8e}  {all_fe[ii]:20.12f}  {all_fe_err[ii]:9.2e}  {all_fe_sys_err[ii]:9.2e}"
             print(line)
@@ -826,7 +832,9 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None):
         "all_fe": list(all_fe),
         "all_fe_stat_err": list(all_fe_err),
         "all_fe_inte_err": list(all_fe_sys_err),
-        "all_fe_tot_err": list(np.linalg.norm(np.vstack([all_fe_err, all_fe_sys_err]), axis=0)),
+        "all_fe_tot_err": list(
+            np.linalg.norm(np.vstack([all_fe_err, all_fe_sys_err]), axis=0)
+        ),
     }
     info = {"start_point_info": info0, "end_point_info": info1, "data": data}
     with open(os.path.join(output_dir, "result"), "w") as f:

--- a/dpti/ti_water.py
+++ b/dpti/ti_water.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from dpti import ti
 from dpti.lib.lammps import get_natoms
+from dpti.lib.output import tee_stdout
 from dpti.lib.utils import get_task_file_abspath
 
 
@@ -148,33 +149,41 @@ def handle_compute(args):
         natoms *= np.prod(jdata["copies"])
     nmols = natoms // 3
     hti_dir = args.hti
-    jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
-    jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
-    if args.Eo is not None and args.hti is not None:
-        raise Warning(
-            "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."
-        )
-    if args.Eo is None:
-        args.Eo = jdata_hti["e1"]
-    if args.Eo_err is None:
-        args.Eo_err = jdata_hti["e1_err"]
-    if args.To is None:
-        args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
-    if args.inte_method == "inte":
-        ti.post_tasks(
-            job,
-            jdata,
-            args.Eo,
-            Eo_err=args.Eo_err,
-            To=args.To,
-            natoms=nmols,
-            scheme=args.scheme,
-            shift=args.shift,
-        )
-    elif args.inte_method == "mbar":
-        ti.post_tasks_mbar(job, jdata, args.Eo, natoms=nmols)
-    else:
-        raise RuntimeError("unknow integration method")
+    output_dir = args.JOB
+    if hti_dir is not None:
+        hti_dir = os.path.normpath(hti_dir)
+        hti_name = os.path.basename(hti_dir)
+        output_dir = os.path.join(args.JOB, hti_name)
+        ti.create_path(output_dir)
+        jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
+        jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
+        if args.Eo is not None and args.hti is not None:
+            raise Warning(
+                "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."
+            )
+        if args.Eo is None:
+            args.Eo = jdata_hti["e1"]
+        if args.Eo_err is None:
+            args.Eo_err = jdata_hti["e1_err"]
+        if args.To is None:
+            args.To = _get_hti_anchor_position(path, jdata_hti, jdata_hti_in)
+    with tee_stdout(os.path.join(output_dir, "result.out")):
+        if args.inte_method == "inte":
+            ti.post_tasks(
+                job,
+                jdata,
+                args.Eo,
+                Eo_err=args.Eo_err,
+                To=args.To,
+                natoms=nmols,
+                scheme=args.scheme,
+                shift=args.shift,
+                output_dir=output_dir,
+            )
+        elif args.inte_method == "mbar":
+            ti.post_tasks_mbar(job, jdata, args.Eo, natoms=nmols, output_dir=output_dir)
+        else:
+            raise RuntimeError("unknow integration method")
 
 
 def handle_refine(args):


### PR DESCRIPTION
## Summary
- store `ti compute` screen output in `result.out`
- when `-H/--hti` is provided, write TI outputs under `JOB/<hti-name>/`
- keep the original root-level output layout for runs without `-H`
- align `ti_water compute` with the same output behavior

## Details
This updates both `dpti ti compute` and `dpti ti_water compute` so that:

- without `-H`, outputs remain in the original locations:
  - `JOB/result.json`
  - `JOB/ti.out`
  - `JOB/result.out`
- with `-H hti.xxx`, outputs are grouped by HTI anchor name:
  - `JOB/hti.xxx/result.json`
  - `JOB/hti.xxx/ti.out`
  - `JOB/hti.xxx/result.out`

The same output redirection is applied to both integration and MBAR compute paths.

## Validation
- verified `dpti ti compute ti.p -H hti.3 -t 50000` now generates:
  - `ti.p/hti.3/result.json`
  - `ti.p/hti.3/ti.out`
  - `ti.p/hti.3/result.out`
- verified `ti_water` module imports correctly after the same output-layout update
