### PR TITLE
feat: organize TI outputs by HTI anchor

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -1151,7 +1151,9 @@ def handle_compute(args):
         hti_dir = os.path.normpath(hti_dir)
         jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
         jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
-        output_dir, _, _ = _make_ti_output_dir(args.JOB, hti_dir, jdata_hti, jdata_hti_in)
+        output_dir, _, _ = _make_ti_output_dir(
+            args.JOB, hti_dir, jdata_hti, jdata_hti_in
+        )
         create_path(output_dir)
         if args.Eo is not None and args.hti is not None:
             raise ValueError(

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -448,7 +448,15 @@ def _thermo_inte(
 
 
 def post_tasks(
-    iter_name, jdata, Eo, Eo_err=0, To=None, natoms=None, scheme="simpson", shift=0.0
+    iter_name,
+    jdata,
+    Eo,
+    Eo_err=0,
+    To=None,
+    natoms=None,
+    scheme="simpson",
+    shift=0.0,
+    output_dir=None,
 ):
     equi_conf = get_task_file_abspath(iter_name, jdata["equi_conf"])
     if natoms is None:
@@ -961,6 +969,39 @@ def _get_hti_anchor_position(path, jdata_hti, jdata_hti_in):
     return None
 
 
+def _format_anchor_value(value):
+    if value is None:
+        return None
+    value = float(value)
+    if value.is_integer():
+        return str(int(value))
+    return format(value, ".10g").replace("+", "")
+
+
+def _get_hti_anchor_tp(jdata_hti, jdata_hti_in):
+    t0 = jdata_hti.get("t0", jdata_hti_in.get("temp"))
+    p0 = None
+    try:
+        p0 = get_first_matched_key_from_dict(jdata_hti, ["p0", "pres", "press"])
+    except KeyError:
+        try:
+            p0 = get_first_matched_key_from_dict(jdata_hti_in, ["pres", "press"])
+        except KeyError:
+            p0 = None
+    return t0, p0
+
+
+def _make_ti_output_dir(job, hti_dir, jdata_hti, jdata_hti_in):
+    hti_name = os.path.basename(os.path.normpath(hti_dir))
+    t0, p0 = _get_hti_anchor_tp(jdata_hti, jdata_hti_in)
+    parts = [hti_name]
+    if t0 is not None:
+        parts.append(f"T0_{_format_anchor_value(t0)}")
+    if p0 is not None:
+        parts.append(f"p0_{_format_anchor_value(p0)}")
+    return os.path.join(job, ".".join(parts)), t0, p0
+
+
 def _is_completed_lammps_task(task_work_path):
     log_file = os.path.join(task_work_path, "log.lammps")
     if not os.path.isfile(log_file):
@@ -1108,11 +1149,10 @@ def handle_compute(args):
     output_dir = args.JOB
     if hti_dir is not None:
         hti_dir = os.path.normpath(hti_dir)
-        hti_name = os.path.basename(hti_dir)
-        output_dir = os.path.join(args.JOB, hti_name)
-        create_path(output_dir)
         jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
         jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
+        output_dir, _, _ = _make_ti_output_dir(args.JOB, hti_dir, jdata_hti, jdata_hti_in)
+        create_path(output_dir)
         if args.Eo is not None and args.hti is not None:
             raise ValueError(
                 "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."

--- a/dpti/ti_water.py
+++ b/dpti/ti_water.py
@@ -154,7 +154,9 @@ def handle_compute(args):
         hti_dir = os.path.normpath(hti_dir)
         jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
         jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
-        output_dir, _, _ = ti._make_ti_output_dir(args.JOB, hti_dir, jdata_hti, jdata_hti_in)
+        output_dir, _, _ = ti._make_ti_output_dir(
+            args.JOB, hti_dir, jdata_hti, jdata_hti_in
+        )
         ti.create_path(output_dir)
         if args.Eo is not None and args.hti is not None:
             raise Warning(

--- a/dpti/ti_water.py
+++ b/dpti/ti_water.py
@@ -152,11 +152,10 @@ def handle_compute(args):
     output_dir = args.JOB
     if hti_dir is not None:
         hti_dir = os.path.normpath(hti_dir)
-        hti_name = os.path.basename(hti_dir)
-        output_dir = os.path.join(args.JOB, hti_name)
-        ti.create_path(output_dir)
         jdata_hti = json.load(open(os.path.join(hti_dir, "result.json")))
         jdata_hti_in = json.load(open(os.path.join(hti_dir, "in.json")))
+        output_dir, _, _ = ti._make_ti_output_dir(args.JOB, hti_dir, jdata_hti, jdata_hti_in)
+        ti.create_path(output_dir)
         if args.Eo is not None and args.hti is not None:
             raise Warning(
                 "Both Eo and hti are provided. Eo will be overrided by the e1 value in hti's result.json file. Make sure this is what you want."


### PR DESCRIPTION
## Summary
- store TI screen output in `result.out`
- remove the redundant plain-text `result` file
- when `-H/--hti` is provided, write outputs under an anchor-specific directory named with HTI job name plus `T0`/`p0`
- add `hti_path`, `T0`, and `p0` to `result.json`
- align `ti_water compute` with the same behavior

## Details
For `dpti ti compute` and `dpti ti_water compute`:

- without `-H`, outputs stay at the original root-level locations:
  - `JOB/result.json`
  - `JOB/ti.out`
  - `JOB/result.out`
- with `-H hti.xxx`, outputs are grouped under:
  - `JOB/<hti_name>.T0_<...>.p0_<...>/result.json`
  - `JOB/<hti_name>.T0_<...>.p0_<...>/ti.out`
  - `JOB/<hti_name>.T0_<...>.p0_<...>/result.out`

This avoids name collisions when different HTI anchors reuse the same HTI folder name.

The generated `result.json` also records:
- `hti_path` (absolute HTI path)
- `T0`
- `p0`

The old plain-text `result` file is no longer written because its content is now covered by `result.out` plus `result.json`.
