### PR TITLE
fix: add TI anchor metadata to result.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: "3.12"
         architecture: x64
     - run: pipx run build
     - name: Publish a Python distribution to PyPI

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/dpti/dags/dp_ti_gdi.py
+++ b/dpti/dags/dp_ti_gdi.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 from datetime import datetime, timedelta
-from typing import ClassVar, Dict
+from typing import ClassVar
 
 from airflow import DAG
 from airflow.api.client.local_client import Client
@@ -30,12 +30,12 @@ from dpti.gdi import gdi_main_loop
 
 
 class GDIDAGFactory:
-    default_args: ClassVar[Dict[str, object]] = {
+    default_args: ClassVar[dict[str, object]] = {
         "owner": "airflow",
         "start_date": datetime(2018, 1, 1),
     }
 
-    dagargs: ClassVar[Dict[str, object]] = {
+    dagargs: ClassVar[dict[str, object]] = {
         "default_args": default_args,
         "schedule_interval": None,
     }

--- a/dpti/equi.py
+++ b/dpti/equi.py
@@ -131,7 +131,7 @@ def gen_equi_dump_settings(if_dump_avg_posi):
     return ret
 
 
-def gen_equi_ensemble_settings(ens, if_dump_avg_posi):
+def gen_equi_ensemble_settings(ens, if_dump_avg_posi=False):
     # ens = equi_settings['ens']
     ret = ""
     if ens == "nvt":

--- a/dpti/hti_liq.py
+++ b/dpti/hti_liq.py
@@ -387,7 +387,9 @@ def make_tasks(iter_name, jdata, if_meam=None):
     if model:
         copied_model = os.path.join(os.path.abspath(iter_name), "graph.pb")
         shutil.copyfile(model, copied_model)
-    jdata["model"] = copied_model
+        jdata["model"] = copied_model
+    else:
+        jdata["model"] = None
 
     cwd = os.getcwd()
     os.chdir(iter_name)

--- a/dpti/lib/utils.py
+++ b/dpti/lib/utils.py
@@ -163,7 +163,7 @@ def parse_seq(in_s, *, protect_eps=None):
             for jj in _parse_one_str(ii):
                 all_l.append(jj)
     elif isinstance(in_s, list) and isinstance(
-        in_s[0], (float, np.float32, np.float64, int)
+        in_s[0], float | np.float32 | np.float64 | int
     ):
         all_l = [float(ii) for ii in in_s]
     elif isinstance(in_s, str):

--- a/dpti/lib/water.py
+++ b/dpti/lib/water.py
@@ -175,7 +175,7 @@ def add_bonds(lines_, max_roh=1.3):
             cc += 1
     for ii in range(sum(natoms)):
         if atype[ii] == 2:
-            mole_idx[ii] = mole_idx[bonds[ii]]
+            mole_idx[ii] = mole_idx[bonds[ii][0]]
     cc = 0
     for idx in range(atoms_idx + 2, atoms_idx + 2 + sum(natoms)):
         words = lines[idx].split()

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -688,9 +688,18 @@ def post_tasks(
     #     all_fe.tolist(), all_fe_err.tolist(), all_fe_sys_err.tolist(),
     #     np.linalg.norm([all_fe_err[ii], all_fe_sys_err[ii]]).tolist()]
     info = {"start_point_info": info0, "end_point_info": info1, "data": data}
-    # print('result', result)
-    with open(os.path.join(output_dir, "result"), "w") as f:
-        f.write(result)
+    if hti_path is not None:
+        info["hti_path"] = os.path.abspath(hti_path)
+        hti_result_json = os.path.join(hti_path, "result.json")
+        hti_input_json = os.path.join(hti_path, "in.json")
+        if os.path.isfile(hti_result_json) and os.path.isfile(hti_input_json):
+            jdata_hti = json.load(open(hti_result_json))
+            jdata_hti_in = json.load(open(hti_input_json))
+            t0, p0 = _get_hti_anchor_tp(jdata_hti, jdata_hti_in)
+            if t0 is not None:
+                info["T0"] = t0
+            if p0 is not None:
+                info["p0"] = p0
     with open(os.path.join(output_dir, "result.json"), "w") as f:
         f.write(json.dumps(info))
     return info

--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -457,6 +457,7 @@ def post_tasks(
     scheme="simpson",
     shift=0.0,
     output_dir=None,
+    hti_path=None,
 ):
     equi_conf = get_task_file_abspath(iter_name, jdata["equi_conf"])
     if natoms is None:
@@ -695,7 +696,7 @@ def post_tasks(
     return info
 
 
-def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None):
+def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None, hti_path=None):
     equi_conf = jdata["equi_conf"]
     if natoms is None:
         natoms = get_natoms(equi_conf)
@@ -845,8 +846,18 @@ def post_tasks_mbar(iter_name, jdata, Eo, natoms=None, output_dir=None):
         ),
     }
     info = {"start_point_info": info0, "end_point_info": info1, "data": data}
-    with open(os.path.join(output_dir, "result"), "w") as f:
-        f.write(result)
+    if hti_path is not None:
+        info["hti_path"] = os.path.abspath(hti_path)
+        hti_result_json = os.path.join(hti_path, "result.json")
+        hti_input_json = os.path.join(hti_path, "in.json")
+        if os.path.isfile(hti_result_json) and os.path.isfile(hti_input_json):
+            jdata_hti = json.load(open(hti_result_json))
+            jdata_hti_in = json.load(open(hti_input_json))
+            t0, p0 = _get_hti_anchor_tp(jdata_hti, jdata_hti_in)
+            if t0 is not None:
+                info["T0"] = t0
+            if p0 is not None:
+                info["p0"] = p0
     with open(os.path.join(output_dir, "result.json"), "w") as f:
         f.write(json.dumps(info))
     return info
@@ -928,7 +939,16 @@ def refine_task(from_task, to_task, err):
             fp.write(from_task_list[back_map[ii]])
 
 
-def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson", output_dir=None):
+def compute_task(
+    job,
+    inte_method,
+    Eo,
+    Eo_err,
+    To,
+    scheme="simpson",
+    output_dir=None,
+    hti_path=None,
+):
     # job = args.JOB
     with open(os.path.join(job, "ti_settings.json")) as f:
         jdata = json.load(f)
@@ -941,9 +961,10 @@ def compute_task(job, inte_method, Eo, Eo_err, To, scheme="simpson", output_dir=
             To=To,
             scheme=scheme,
             output_dir=output_dir,
+            hti_path=hti_path,
         )
     elif inte_method == "mbar":
-        info = post_tasks_mbar(job, jdata, Eo, output_dir=output_dir)
+        info = post_tasks_mbar(job, jdata, Eo, output_dir=output_dir, hti_path=hti_path)
     else:
         raise RuntimeError("unknow integration method")
     return info
@@ -1175,6 +1196,7 @@ def handle_compute(args):
             To=args.To,
             scheme=args.scheme,
             output_dir=output_dir,
+            hti_path=hti_dir,
         )
     #     job = args.JOB
     #     jdata = json.load(open(os.path.join(job, 'in.json'), 'r'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,13 @@ description = "Python dpti for thermodynamics integration"
 authors = [{ name = "Deep Modeling Team" }]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 readme = "README.md"
-requires-python = ">3.6"
+requires-python = ">=3.10"
 keywords = ["free energy", "thermodynamics integration", "deepmd-kit"]
 dependencies = [
     "apache-airflow >= 2.0",

--- a/tests/benchmark_hti_liq/three_step/00.soft_on/task.000004/in.lammps
+++ b/tests/benchmark_hti_liq/three_step/00.soft_on/task.000004/in.lammps
@@ -19,17 +19,18 @@ read_data       conf.lmp
 change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
-variable        EPSILON equal 0.010000
 pair_style      lj/cut/soft 1.000000 0.500000 6.000000
-pair_coeff      1 1 ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes
+variable        EPSILON equal 0.010000
 compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/benchmark_hti_liq/three_step/01.deep_on/task.000005/in.lammps
+++ b/tests/benchmark_hti_liq/three_step/01.deep_on/task.000005/in.lammps
@@ -19,19 +19,19 @@ read_data       conf.lmp
 change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
-variable        EPSILON equal 0.010000
 variable        ONE equal 1
 pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
 pair_coeff      * * deepmd
-pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 lj/cut/soft 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair deepmd scale * * v_LAMBDA
 compute         e_diff all fep ${TEMP} pair deepmd scale * * v_ONE
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/benchmark_hti_liq/three_step/02.soft_off/task.000006/in.lammps
+++ b/tests/benchmark_hti_liq/three_step/02.soft_off/task.000006/in.lammps
@@ -20,19 +20,19 @@ change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
 variable        INV_LAMBDA equal 1-${LAMBDA}
-variable        EPSILON equal 0.010000
-variable        INV_EPSILON equal -${EPSILON}
 pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
 pair_coeff      * * deepmd
-pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 lj/cut/soft 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+variable        EPSILON equal -0.010000
+compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/benchmark_hti_liq/three_step_meam/00.soft_on/task.000004/in.lammps
+++ b/tests/benchmark_hti_liq/three_step_meam/00.soft_on/task.000004/in.lammps
@@ -19,17 +19,18 @@ read_data       conf.lmp
 change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
-variable        EPSILON equal 0.010000
 pair_style      lj/cut/soft 1.000000 0.500000 6.000000
-pair_coeff      1 1 ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes
+variable        EPSILON equal 0.010000
 compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/benchmark_hti_liq/three_step_meam/01.deep_on/task.000005/in.lammps
+++ b/tests/benchmark_hti_liq/three_step_meam/01.deep_on/task.000005/in.lammps
@@ -19,19 +19,19 @@ read_data       conf.lmp
 change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
-variable        EPSILON equal 0.010000
 variable        ONE equal 1
 pair_style      hybrid/overlay meam lj/cut/soft 1.000000 0.500000 6.000000
 pair_coeff      * * meam library_18Metals.meam Sn Sn_18Metals.meam Sn
-pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 lj/cut/soft 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair meam scale * * v_LAMBDA
 compute         e_diff all fep ${TEMP} pair meam scale * * v_ONE
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/benchmark_hti_liq/three_step_meam/02.soft_off/task.000006/in.lammps
+++ b/tests/benchmark_hti_liq/three_step_meam/02.soft_off/task.000006/in.lammps
@@ -20,19 +20,19 @@ change_box      all triclinic
 mass            1 118.710000
 # --------------------- FORCE FIELDS ---------------------
 variable        INV_LAMBDA equal 1-${LAMBDA}
-variable        EPSILON equal 0.010000
-variable        INV_EPSILON equal -${EPSILON}
 pair_style      hybrid/overlay meam lj/cut/soft 1.000000 0.500000 6.000000
 pair_coeff      * * meam library_18Metals.meam Sn Sn_18Metals.meam Sn
-pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.527854 0.500000
+pair_coeff      1 1 lj/cut/soft 0.010000 2.527854 0.500000
 fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+variable        EPSILON equal -0.010000
+compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+variable        e_diff equal c_e_diff[1]
 # --------------------- MD SETTINGS ----------------------
 neighbor        1.0 bin
 timestep        0.002
 compute         allmsd all msd
 thermo          ${THERMO_FREQ}
-thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
 thermo_modify   format 9 %.16e
 dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
 fix             1 all nvt temp ${TEMP} ${TEMP} ${TAU_T}

--- a/tests/test_hti_liq_deep_on.py
+++ b/tests/test_hti_liq_deep_on.py
@@ -20,13 +20,13 @@ class TestDeepOn(unittest.TestCase):
         }
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         variable        ONE equal 1
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair deepmd scale * * v_LAMBDA
         compute         e_diff all fep ${TEMP} pair deepmd scale * * v_ONE
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_deep_on(**input)
@@ -43,18 +43,18 @@ class TestDeepOn(unittest.TestCase):
 
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         variable        ONE equal 1
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.600000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.000000 0.500000
-        pair_coeff      1 2 lj/cut/soft ${EPSILON} 2.010000 0.500000
-        pair_coeff      1 3 lj/cut/soft ${EPSILON} 2.020000 0.500000
-        pair_coeff      2 2 lj/cut/soft ${EPSILON} 2.110000 0.500000
-        pair_coeff      2 3 lj/cut/soft ${EPSILON} 2.120000 0.500000
-        pair_coeff      3 3 lj/cut/soft ${EPSILON} 2.220000 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.000000 0.500000
+        pair_coeff      1 2 lj/cut/soft 0.030000 2.010000 0.500000
+        pair_coeff      1 3 lj/cut/soft 0.030000 2.020000 0.500000
+        pair_coeff      2 2 lj/cut/soft 0.030000 2.110000 0.500000
+        pair_coeff      2 3 lj/cut/soft 0.030000 2.120000 0.500000
+        pair_coeff      3 3 lj/cut/soft 0.030000 2.220000 0.500000
         fix             tot_pot all adapt/fep 0 pair deepmd scale * * v_LAMBDA
         compute         e_diff all fep ${TEMP} pair deepmd scale * * v_ONE
+        variable        e_diff equal c_e_diff[1]
         """
         )
 
@@ -71,13 +71,13 @@ class TestDeepOn(unittest.TestCase):
         }
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         variable        ONE equal 1
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair deepmd scale * * v_LAMBDA
         compute         e_diff all fep ${TEMP} pair deepmd scale * * v_ONE
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_deep_on(**input)
@@ -100,13 +100,13 @@ class TestDeepOn(unittest.TestCase):
         }
         ret1 = textwrap.dedent(
             """\
-        variable        EPSILON equal 0.030000
         variable        ONE equal 1
         pair_style      hybrid/overlay meam lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * meam library_18Metals.meam Sn Sn_18Metals.meam Sn
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair meam scale * * v_LAMBDA
         compute         e_diff all fep ${TEMP} pair meam scale * * v_ONE
+        variable        e_diff equal c_e_diff[1]
         """
         )
         ret2 = _ff_deep_on(**input)

--- a/tests/test_hti_liq_gen_lammps_input.py
+++ b/tests/test_hti_liq_gen_lammps_input.py
@@ -63,17 +63,18 @@ class TestGenLammpsIdeal(unittest.TestCase):
         change_box      all triclinic
         mass            1 118.710000
         # --------------------- FORCE FIELDS ---------------------
-        variable        EPSILON equal 0.030000
         pair_style      lj/cut/soft 1.000000 0.500000 6.000000
-        pair_coeff      1 1 ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_LAMBDA scale yes
+        variable        EPSILON equal 0.030000
         compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         # --------------------- MD SETTINGS ----------------------
         neighbor        1.0 bin
         timestep        0.002
         compute         allmsd all msd
         thermo          ${THERMO_FREQ}
-        thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+        thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
         thermo_modify   format 9 %.16e
         dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
         fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
@@ -141,19 +142,19 @@ class TestGenLammpsIdeal(unittest.TestCase):
         change_box      all triclinic
         mass            1 118.710000
         # --------------------- FORCE FIELDS ---------------------
-        variable        EPSILON equal 0.030000
         variable        ONE equal 1
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair deepmd scale * * v_LAMBDA
         compute         e_diff all fep ${TEMP} pair deepmd scale * * v_ONE
+        variable        e_diff equal c_e_diff[1]
         # --------------------- MD SETTINGS ----------------------
         neighbor        1.0 bin
         timestep        0.002
         compute         allmsd all msd
         thermo          ${THERMO_FREQ}
-        thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+        thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
         thermo_modify   format 9 %.16e
         dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
         fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}
@@ -223,19 +224,19 @@ class TestGenLammpsIdeal(unittest.TestCase):
         mass            1 118.710000
         # --------------------- FORCE FIELDS ---------------------
         variable        INV_LAMBDA equal 1-${LAMBDA}
-        variable        EPSILON equal 0.030000
-        variable        INV_EPSILON equal -${EPSILON}
         pair_style      hybrid/overlay deepmd graph.pb lj/cut/soft 1.000000 0.500000 6.000000
         pair_coeff      * * deepmd
-        pair_coeff      1 1 lj/cut/soft ${EPSILON} 2.493672 0.500000
+        pair_coeff      1 1 lj/cut/soft 0.030000 2.493672 0.500000
         fix             tot_pot all adapt/fep 0 pair lj/cut/soft epsilon * * v_INV_LAMBDA scale yes
-        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_INV_EPSILON
+        variable        EPSILON equal -0.030000
+        compute         e_diff all fep ${TEMP} pair lj/cut/soft epsilon * * v_EPSILON
+        variable        e_diff equal c_e_diff[1]
         # --------------------- MD SETTINGS ----------------------
         neighbor        1.0 bin
         timestep        0.002
         compute         allmsd all msd
         thermo          ${THERMO_FREQ}
-        thermo_style    custom step ke pe etotal enthalpy temp press vol c_e_diff[1] c_allmsd[*]
+        thermo_style    custom step ke pe etotal enthalpy temp press vol v_e_diff c_allmsd[*]
         thermo_modify   format 9 %.16e
         dump            1 all custom ${DUMP_FREQ} dump.hti id type x y z vx vy vz
         fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P}


### PR DESCRIPTION
Add the missing TI anchor metadata fields (`hti_path`, `T0`, `p0`) to `result.json` and stop writing the redundant plain-text `result` file. This builds on the already-merged anchor-aware TI output directory layout and `result.out` support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTI path parameter to augment thermal integration results with anchor temperature and pressure information.

* **Chores**
  * Updated CI workflows to test on Python 3.10, 3.11, and 3.12.
  * Dropped support for Python 3.7–3.9; minimum required version is now Python 3.10.
  * Updated LAMMPS test configurations for improved parameter handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/dpti/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->