### PR TITLE
Print potential energy in MTI outputs

### DIFF
--- a/dpti/mti.py
+++ b/dpti/mti.py
@@ -98,13 +98,13 @@ def _gen_lammps_input(
     else:
         raise RuntimeError(f"unknow ensemble {ens}\n")
     if ens == "nvt" or ens == "nve":
-        ret += "thermo_style    custom step temp f_1[5] f_1[7] c_allmsd[*]\n"
+        ret += "thermo_style    custom step temp pe f_1[5] f_1[7] c_allmsd[*]\n"
         ret += "thermo_modify   format float %6.8e\n"
-        ret += 'fix print all print ${THERMO_FREQ} "$(step) $(temp) $(f_1[5]) $(f_1[7])" append ${ibead}.out title "# step temp K_prim K_cv" screen no'
+        ret += 'fix print all print ${THERMO_FREQ} "$(step) $(temp) $(pe) $(f_1[5]) $(f_1[7])" append ${ibead}.out title "# step temp pe K_prim K_cv" screen no'
     elif "npt" in ens:
-        ret += "thermo_style    custom step temp vol density f_1[5] f_1[7] f_1[8] f_1[10] c_allmsd[*]\n"
+        ret += "thermo_style    custom step temp vol density pe f_1[5] f_1[7] f_1[8] f_1[10] c_allmsd[*]\n"
         ret += "thermo_modify   format float %6.8e\n"
-        ret += 'fix print all print ${THERMO_FREQ} "$(step) $(temp) $(vol) $(density) $(f_1[5]) $(f_1[7])" append ${ibead}.out title "# step temp vol density K_prim K_cv" screen no'
+        ret += 'fix print all print ${THERMO_FREQ} "$(step) $(temp) $(vol) $(density) $(pe) $(f_1[5]) $(f_1[7])" append ${ibead}.out title "# step temp vol density pe K_prim K_cv" screen no'
     else:
         raise RuntimeError(f"unknow ensemble {ens}\n")
     ret += "# --------------------- INITIALIZE -----------------------\n"

--- a/tests/test_mti_gen_lammps_input.py
+++ b/tests/test_mti_gen_lammps_input.py
@@ -1,0 +1,58 @@
+import unittest
+
+from dpti import mti
+
+
+class TestMtiGenLammpsInput(unittest.TestCase):
+    def test_npt_prints_potential_energy(self):
+        ret = mti._gen_lammps_input(
+            conf_file="conf.lmp",
+            mass_map=[16.0, 1.0],
+            mass_scale=1.0,
+            model="graph.pb",
+            template_ff=None,
+            nbeads=64,
+            nsteps=1000,
+            timestep=0.0005,
+            ens="npt",
+            temp=300,
+            pres=1.0,
+            tau_t=0.1,
+            tau_p=0.5,
+            thermo_freq=10,
+            dump_freq=100,
+        )
+
+        self.assertIn(
+            "thermo_style    custom step temp vol density pe f_1[5] f_1[7]",
+            ret,
+        )
+        self.assertIn(
+            '"$(step) $(temp) $(vol) $(density) $(pe) $(f_1[5]) $(f_1[7])"',
+            ret,
+        )
+        self.assertIn("# step temp vol density pe K_prim K_cv", ret)
+
+    def test_nvt_prints_potential_energy(self):
+        ret = mti._gen_lammps_input(
+            conf_file="conf.lmp",
+            mass_map=[16.0, 1.0],
+            mass_scale=1.0,
+            model="graph.pb",
+            template_ff=None,
+            nbeads=64,
+            nsteps=1000,
+            timestep=0.0005,
+            ens="nvt",
+            temp=300,
+            thermo_freq=10,
+            dump_freq=100,
+        )
+
+        self.assertIn("thermo_style    custom step temp pe f_1[5] f_1[7]", ret)
+        self.assertIn('"$(step) $(temp) $(pe) $(f_1[5]) $(f_1[7])"', ret)
+        self.assertIn("# step temp pe K_prim K_cv", ret)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- include potential energy in MTI-generated LAMMPS thermo output for NVT/NVE and NPT ensembles
- include the $(pe) column in bead-level output files with matching headers
- add focused tests for MTI LAMMPS input generation

## Tests
- mamba run -n dpti pytest tests/test_mti_gen_lammps_input.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LAMMPS output now includes potential energy in thermodynamic data for all supported ensemble types, with updated column ordering.

* **Tests**
  * Added unit tests to validate potential energy reporting across different simulation ensembles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->