### PR TITLE
Support phase-specific models in GDI

### DIFF
--- a/dpti/gdi.py
+++ b/dpti/gdi.py
@@ -106,9 +106,11 @@ def _make_tasks_onephase(
     os.chdir(task_path)
     if not os.path.exists("conf.lmp"):
         os.symlink(os.path.relpath(conf_file), "conf.lmp")
+    local_graph_file = graph_file
     if graph_file:
         if not os.path.exists("graph.pb"):
             os.symlink(os.path.relpath(graph_abs_file), "graph.pb")
+        local_graph_file = "graph.pb"
 
     if if_meam:
         relative_link_file(meam_model["library_abs_path"], "./")
@@ -122,7 +124,7 @@ def _make_tasks_onephase(
     lmp_str = _gen_lammps_input(
         "conf.lmp",
         mass_map,
-        graph_file,
+        local_graph_file,
         nsteps,
         timestep,
         ens,
@@ -144,6 +146,26 @@ def _make_tasks_onephase(
     # end _make_tasks_onephase
 
 
+def _get_phase_model(jdata, phase_key):
+    phase_model = jdata[phase_key].get("model")
+    if phase_model is not None:
+        return phase_model
+    return jdata.get("model")
+
+
+def _has_phase_specific_model(jdata):
+    return (
+        jdata["phase_i"].get("model") is not None
+        or jdata["phase_ii"].get("model") is not None
+    )
+
+
+def _get_phase_graph_file(jdata, phase_idx):
+    if _has_phase_specific_model(jdata):
+        return f"graph.{phase_idx}.pb"
+    return "graph.pb"
+
+
 def _setup_dpdt(task_path, jdata):
     name_0 = jdata["phase_i"]["name"]
     name_1 = jdata["phase_ii"]["name"]
@@ -151,22 +173,30 @@ def _setup_dpdt(task_path, jdata):
     conf_1 = os.path.join(task_path, "../", jdata["phase_ii"]["equi_conf"])
     conf_0 = os.path.abspath(conf_0)
     conf_1 = os.path.abspath(conf_1)
-    model = os.path.join(task_path, "../", jdata["model"])
-    if model:
-        model = os.path.abspath(model)
+    model_0 = _get_phase_model(jdata, "phase_i")
+    model_1 = _get_phase_model(jdata, "phase_ii")
+    if model_0:
+        model_0 = os.path.abspath(os.path.join(task_path, "../", model_0))
+    if model_1:
+        model_1 = os.path.abspath(os.path.join(task_path, "../", model_1))
 
     task_abs_dir = create_path(task_path)
     conf_0_name = f"conf.{'0'}.lmp"
     conf_1_name = f"conf.{'1'}.lmp"
+    model_0_name = _get_phase_graph_file(jdata, 0)
+    model_1_name = _get_phase_graph_file(jdata, 1)
     # conf_0_name = 'conf.%s.lmp' % name_0
     # conf_1_name = 'conf.%s.lmp' % name_1
     copied_conf_0 = os.path.join(os.path.abspath(task_path), conf_0_name)
     copied_conf_1 = os.path.join(os.path.abspath(task_path), conf_1_name)
     shutil.copyfile(conf_0, copied_conf_0)
     shutil.copyfile(conf_1, copied_conf_1)
-    if model:
-        linked_model = os.path.join(os.path.abspath(task_path), "graph.pb")
-        shutil.copyfile(model, linked_model)
+    if model_0:
+        copied_model_0 = os.path.join(os.path.abspath(task_path), model_0_name)
+        shutil.copyfile(model_0, copied_model_0)
+    if model_1:
+        copied_model_1 = os.path.join(os.path.abspath(task_path), model_1_name)
+        shutil.copyfile(model_1, copied_model_1)
 
     with open(os.path.join(os.path.abspath(task_path), "in.json"), "w") as fp:
         json.dump(jdata, fp, indent=4)
@@ -267,7 +297,7 @@ def make_dpdt(
             jdata,
             ens=jdata["phase_i"].get("ens", None),
             conf_file=conf_0,
-            graph_file="graph.pb",
+            graph_file=_get_phase_graph_file(jdata, 0),
             if_meam=if_meam,
             meam_model=meam_model,
         )
@@ -278,7 +308,7 @@ def make_dpdt(
             jdata,
             ens=jdata["phase_ii"].get("ens", None),
             conf_file=conf_1,
-            graph_file="graph.pb",
+            graph_file=_get_phase_graph_file(jdata, 1),
             if_meam=if_meam,
             meam_model=meam_model,
         )

--- a/tests/test_gdi_make_task.py
+++ b/tests/test_gdi_make_task.py
@@ -48,6 +48,186 @@ class TestGdiMakeTask(unittest.TestCase):
             f2 = os.path.join(test_dir, file)
             self.assertEqual(get_file_md5(f1), get_file_md5(f2), msg=(f1, f2))
 
+    def test_setup_dpdt_phase_specific_models(self):
+        parent_dir = os.path.join(self.test_dir, "phase_models")
+        task_dir = os.path.join(parent_dir, "gdi_job")
+        os.makedirs(parent_dir)
+        shutil.copyfile("conf.lmp", os.path.join(parent_dir, "conf.0.lmp"))
+        shutil.copyfile("alpha.lmp", os.path.join(parent_dir, "conf.1.lmp"))
+        shutil.copyfile("graph.pb", os.path.join(parent_dir, "graph.0.pb"))
+        shutil.copyfile("beta.lmp", os.path.join(parent_dir, "graph.1.pb"))
+        jdata = {
+            "phase_i": {
+                "name": "PHASE_0",
+                "equi_conf": "conf.0.lmp",
+                "model": "graph.0.pb",
+            },
+            "phase_ii": {
+                "name": "PHASE_1",
+                "equi_conf": "conf.1.lmp",
+                "model": "graph.1.pb",
+            },
+            "mass_map": [118.71],
+            "nsteps": 5000,
+            "timestep": 0.002,
+            "tau_t": 0.1,
+            "tau_p": 1.0,
+            "thermo_freq": 10,
+            "stat_skip": 100,
+            "stat_bsize": 10,
+        }
+
+        dpti.gdi._setup_dpdt(task_dir, jdata)
+
+        for file in ["conf.0.lmp", "conf.1.lmp", "graph.0.pb", "graph.1.pb"]:
+            f1 = os.path.join(parent_dir, file)
+            f2 = os.path.join(task_dir, file)
+            self.assertEqual(get_file_md5(f1), get_file_md5(f2), msg=(f1, f2))
+
+    def test_setup_dpdt_top_level_model_uses_legacy_graph_name(self):
+        parent_dir = os.path.join(self.test_dir, "top_level_model")
+        task_dir = os.path.join(parent_dir, "gdi_job")
+        os.makedirs(parent_dir)
+        shutil.copyfile("conf.lmp", os.path.join(parent_dir, "conf.0.lmp"))
+        shutil.copyfile("alpha.lmp", os.path.join(parent_dir, "conf.1.lmp"))
+        shutil.copyfile("graph.pb", os.path.join(parent_dir, "graph.pb"))
+        jdata = {
+            "phase_i": {
+                "name": "PHASE_0",
+                "equi_conf": "conf.0.lmp",
+            },
+            "phase_ii": {
+                "name": "PHASE_1",
+                "equi_conf": "conf.1.lmp",
+            },
+            "model": "graph.pb",
+            "mass_map": [118.71],
+            "nsteps": 5000,
+            "timestep": 0.002,
+            "tau_t": 0.1,
+            "tau_p": 1.0,
+            "thermo_freq": 10,
+            "stat_skip": 100,
+            "stat_bsize": 10,
+        }
+
+        dpti.gdi._setup_dpdt(task_dir, jdata)
+
+        self.assertEqual(
+            dpti.gdi._get_phase_graph_file(jdata, 0),
+            "graph.pb",
+        )
+        self.assertEqual(
+            dpti.gdi._get_phase_graph_file(jdata, 1),
+            "graph.pb",
+        )
+        self.assertTrue(os.path.isfile(os.path.join(task_dir, "graph.pb")))
+        self.assertFalse(os.path.exists(os.path.join(task_dir, "graph.0.pb")))
+        self.assertFalse(os.path.exists(os.path.join(task_dir, "graph.1.pb")))
+
+    def test_setup_dpdt_water_gdi_input_layout(self):
+        parent_dir = os.path.join(self.test_dir, "water_gdi")
+        gdi_dir = os.path.join(parent_dir, "gdi")
+        task_dir = os.path.join(gdi_dir, "new_job")
+        os.makedirs(gdi_dir)
+        shutil.copyfile("graph.pb", os.path.join(parent_dir, "graph.pb"))
+        shutil.copyfile("conf.lmp", os.path.join(gdi_dir, "conf.ice.150K.lmp"))
+        shutil.copyfile("alpha.lmp", os.path.join(gdi_dir, "conf.water.300K.lmp"))
+        jdata = {
+            "model": "../graph.pb",
+            "model_mass_map": [16, 1],
+            "nsteps": 200000,
+            "dt": 0.0005,
+            "tau_t": 0.1,
+            "tau_p": 0.5,
+            "stat_freq": 100,
+            "dump_freq": 10000,
+            "stat_skip": 200,
+            "stat_bsize": 100,
+            "phase_i": {
+                "name": "ice_Ih",
+                "equi_conf": "conf.ice.150K.lmp",
+                "ens": "npt-aniso",
+            },
+            "phase_ii": {
+                "name": "water",
+                "equi_conf": "conf.water.300K.lmp",
+                "ens": "npt",
+            },
+        }
+
+        dpti.gdi._setup_dpdt(task_dir, jdata)
+
+        self.assertTrue(os.path.isfile(os.path.join(task_dir, "graph.pb")))
+        self.assertFalse(os.path.exists(os.path.join(task_dir, "graph.0.pb")))
+        self.assertFalse(os.path.exists(os.path.join(task_dir, "graph.1.pb")))
+        self.assertEqual(dpti.gdi._get_phase_graph_file(jdata, 0), "graph.pb")
+        self.assertEqual(dpti.gdi._get_phase_graph_file(jdata, 1), "graph.pb")
+
+    def test_setup_dpdt_silica_phase_specific_input_layout(self):
+        parent_dir = os.path.join(self.test_dir, "silica_gdi")
+        task_dir = os.path.join(parent_dir, "new_job")
+        os.makedirs(parent_dir)
+        shutil.copyfile("conf.lmp", os.path.join(parent_dir, "conf_solid.lmp"))
+        shutil.copyfile("alpha.lmp", os.path.join(parent_dir, "conf_melt.lmp"))
+        shutil.copyfile("graph.pb", os.path.join(parent_dir, "graph_solid.pb"))
+        shutil.copyfile("beta.lmp", os.path.join(parent_dir, "graph_melt.pb"))
+        jdata = {
+            "phase_i": {
+                "name": "BETA_QUARTZ",
+                "equi_conf": "conf_solid.lmp",
+                "model": "graph_solid.pb",
+                "ens": "npt-aniso",
+            },
+            "phase_ii": {
+                "name": "MELT",
+                "equi_conf": "conf_melt.lmp",
+                "model": "graph_melt.pb",
+                "ens": "npt-iso",
+            },
+            "mass_map": [28.085, 15.999],
+            "nsteps": 1000000,
+            "timestep": 0.002,
+            "tau_t": 0.1,
+            "tau_p": 1.0,
+            "thermo_freq": 10,
+            "dump_freq": 5000,
+            "stat_skip": 25000,
+            "stat_bsize": 100,
+        }
+
+        dpti.gdi._setup_dpdt(task_dir, jdata)
+
+        for file in ["conf.0.lmp", "conf.1.lmp", "graph.0.pb", "graph.1.pb"]:
+            self.assertTrue(os.path.isfile(os.path.join(task_dir, file)))
+        self.assertEqual(dpti.gdi._get_phase_graph_file(jdata, 0), "graph.0.pb")
+        self.assertEqual(dpti.gdi._get_phase_graph_file(jdata, 1), "graph.1.pb")
+
+    @patch("numpy.random.default_rng")
+    def test_deepmd_uses_local_graph_name(self, patch_random):
+        patch_random.return_value = MagicMock(integers=MagicMock(return_value=7858))
+        test_dir = os.path.join(self.test_dir, "deepmd_local_graph")
+        json_file = os.path.join(self.benchmark_dir, "deepmd", "pb.json")
+        with open(json_file) as f:
+            jdata = json.load(f)
+
+        dpti.gdi._make_tasks_onephase(
+            temp=300,
+            pres=50000,
+            task_path=test_dir,
+            jdata=jdata,
+            ens="npt",
+            conf_file="conf.lmp",
+            graph_file="graph.0.pb",
+            if_meam=False,
+            meam_model=None,
+        )
+
+        with open(os.path.join(test_dir, "in.lammps")) as fp:
+            lmp_input = fp.read()
+        self.assertIn("pair_style      deepmd graph.pb", lmp_input)
+        self.assertNotIn("pair_style      deepmd graph.0.pb", lmp_input)
+
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree("tmp_gdi/")


### PR DESCRIPTION
## Summary
- allow GDI inputs to specify `phase_i.model` and `phase_ii.model`
- keep backward compatibility by falling back to the top-level `model` and preserving the legacy `graph.pb` name when no phase-specific models are used
- copy phase models as `graph.0.pb` and `graph.1.pb` only for phase-specific model inputs, and use local `graph.pb` links in generated phase tasks
- add focused tests for phase-specific model setup, top-level model compatibility, local graph names, and the water/silica GDI input layouts used in existing workflows

## Tests
- `mamba run -n dpti pytest test_gdi_make_task.py` from `tests/`: 6 passed
- one-off validation using the hydrated water and silica `in.gdi.json` files: water keeps `graph.pb`; silica creates `graph.0.pb` and `graph.1.pb`