### PR TITLE
Fix COM correction in pressure integration

### DIFF
--- a/dpti/ti.py
+++ b/dpti/ti.py
@@ -557,14 +557,11 @@ def post_tasks(
             ea, ee = block_avg(data[:, stat_col], skip=stat_skip, block_size=stat_bsize)
         enthalpy, _ = block_avg(data[:, 4], skip=stat_skip, block_size=stat_bsize)
         msd_xyz = data[-1, -1]
-        # COM corr
+        # COM kinetic-energy correction applies only to temperature paths
         if path == "t" or path == "t-ginv":
             ea += 1.5 * pc.Boltzmann * tt / pc.electron_volt
             # print('~~', tt, ea, 1.5 * pc.Boltzmann * tt / pc.electron_volt)
-        elif path == "p":
-            temp = jdata["temp"]
-            ea += 1.5 * pc.Boltzmann * temp / pc.electron_volt
-        else:
+        elif path != "p":
             raise RuntimeError("invalid path setting")
         # normalized by number of atoms
         ea /= natoms

--- a/tests/test_ti_post_tasks.py
+++ b/tests/test_ti_post_tasks.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from context import dpti
+
+
+class TestTiPostTasks(unittest.TestCase):
+    def test_pressure_path_does_not_add_com_energy_to_volume(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conf = os.path.join(tmpdir, "conf.lmp")
+            with open(conf, "w") as fp:
+                fp.write("2 atoms\n")
+
+            task = os.path.join(tmpdir, "task.000000")
+            os.mkdir(task)
+            with open(os.path.join(task, "thermo.out"), "w") as fp:
+                fp.write("10000")
+
+            thermo = np.zeros((2, 12))
+            thermo[:, 4] = 20.0
+            thermo[:, 5] = 1600.0
+            thermo[:, 6] = 10000.0
+            thermo[:, 7] = 100.0
+
+            jdata = {
+                "equi_conf": conf,
+                "stat_skip": 0,
+                "stat_bsize": 1,
+                "ens": "npt",
+                "path": "p",
+                "temp": 1600.0,
+            }
+
+            with patch("dpti.ti.get_thermo", return_value=thermo):
+                dpti.ti.post_tasks(
+                    tmpdir,
+                    jdata,
+                    Eo=0.0,
+                    natoms=2,
+                    scheme="trapezoidal",
+                )
+
+            output = np.loadtxt(os.path.join(tmpdir, "ti.out"), ndmin=2)
+            volume_per_atom = output[0, 2]
+            self.assertEqual(volume_per_atom, 50.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- apply the center-of-mass kinetic-energy correction only to temperature-integration paths
- leave pressure-integration volumes unchanged
- add a regression test for the pTI post-processing output

## Background

For a pressure path, `ea` is the sampled volume. The previous code added
`3 k_B T / 2`, an energy, before treating the result as a volume and converting
it to the pTI integrand. The COM kinetic-energy correction is relevant to TTI
enthalpy, but not to the pTI integrand `dG/dp = <V>`.

## Validation

- `conda run -n dpti python -m pytest -q test_ti_post_tasks.py test_ti_make_task.py test_ti_gen_lammps_input.py` (7 passed)
- `pre-commit run ruff --files dpti/ti.py tests/test_ti_post_tasks.py`
- `pre-commit run ruff-format --files dpti/ti.py tests/test_ti_post_tasks.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pressure-path calculations so center-of-mass energy no longer incorrectly alters reported volume results.
  * Preserved center-of-mass kinetic-energy correction for applicable temperature-path integrations.
* **Tests**
  * Added coverage to verify pressure-path volume calculations remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->